### PR TITLE
Fix vendor centroiding for Thermo raw data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,6 @@ default = ["thermo"]
 thermo = ["mzdata/thermo"]
 
 [dependencies]
+pyo3 = { version = "0.23.3", features = ["anyhow"] }
 mzdata = "0.39.0"
 timsrust = "0.4.1"
-
-[dependencies.pyo3]
-version = "0.23.3"
-features = ["anyhow"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ thermo = ["mzdata/thermo"]
 
 [dependencies]
 mzdata = "0.39.0"
-timsrust = "0.3.0"
+timsrust = "0.4.1"
 
 [dependencies.pyo3]
 version = "0.23.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms2rescore-rs"
-version = "0.4.0-1"
+version = "0.4.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,10 +10,12 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["thermo"]
-
 thermo = ["mzdata/thermo"]
 
 [dependencies]
-pyo3 = "0.20.0"
-mzdata = "0.33.0"
+mzdata = "0.39.0"
 timsrust = "0.3.0"
+
+[dependencies.pyo3]
+version = "0.23.3"
+features = ["anyhow"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 mod file_types;
+mod ms2_spectrum;
 mod parse_mzdata;
 mod parse_timsrust;
 mod precursor;
-mod ms2_spectrum;
 
 use std::collections::HashMap;
 
@@ -10,8 +10,8 @@ use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::*;
 
 use file_types::{match_file_type, SpectrumFileType};
-use precursor::Precursor;
 use ms2_spectrum::MS2Spectrum;
+use precursor::Precursor;
 
 /// Check if spectrum path matches a supported file type.
 #[pyfunction]
@@ -27,9 +27,10 @@ pub fn get_precursor_info(spectrum_path: String) -> PyResult<HashMap<String, Pre
     let file_type = match_file_type(&spectrum_path);
 
     let precursors = match file_type {
-        SpectrumFileType::MascotGenericFormat | SpectrumFileType::MzML | SpectrumFileType::MzMLb | SpectrumFileType:: ThermoRaw => {
-            parse_mzdata::parse_precursor_info(&spectrum_path)
-        }
+        SpectrumFileType::MascotGenericFormat
+        | SpectrumFileType::MzML
+        | SpectrumFileType::MzMLb
+        | SpectrumFileType::ThermoRaw => parse_mzdata::parse_precursor_info(&spectrum_path),
         SpectrumFileType::BrukerRaw => parse_timsrust::parse_precursor_info(&spectrum_path),
         SpectrumFileType::Unknown => return Err(PyValueError::new_err("Unsupported file type")),
     };
@@ -46,9 +47,10 @@ pub fn get_ms2_spectra(spectrum_path: String) -> PyResult<Vec<ms2_spectrum::MS2S
     let file_type = match_file_type(&spectrum_path);
 
     let spectra = match file_type {
-        SpectrumFileType::MascotGenericFormat | SpectrumFileType::MzML | SpectrumFileType::MzMLb | SpectrumFileType:: ThermoRaw => {
-            parse_mzdata::read_ms2_spectra(&spectrum_path)
-        }
+        SpectrumFileType::MascotGenericFormat
+        | SpectrumFileType::MzML
+        | SpectrumFileType::MzMLb
+        | SpectrumFileType::ThermoRaw => parse_mzdata::read_ms2_spectra(&spectrum_path),
         SpectrumFileType::BrukerRaw => parse_timsrust::read_ms2_spectra(&spectrum_path),
         SpectrumFileType::Unknown => return Err(PyValueError::new_err("Unsupported file type")),
     };
@@ -59,10 +61,9 @@ pub fn get_ms2_spectra(spectrum_path: String) -> PyResult<Vec<ms2_spectrum::MS2S
     }
 }
 
-
 /// A Python module implemented in Rust.
 #[pymodule]
-fn ms2rescore_rs(_py: Python, m: &PyModule) -> PyResult<()> {
+fn ms2rescore_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Precursor>()?;
     m.add_class::<MS2Spectrum>()?;
     m.add_function(wrap_pyfunction!(is_supported_file_type, m)?)?;

--- a/src/parse_mzdata.rs
+++ b/src/parse_mzdata.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
-use mzdata::params::ParamValue;
-use mzdata::mz_read;
+use mzdata::{params::ParamValue, prelude::*, MZReader};
 
 use crate::ms2_spectrum::MS2Spectrum;
 use crate::precursor::Precursor;
@@ -49,25 +48,31 @@ impl From<mzdata::spectrum::MultiLayerSpectrum> for MS2Spectrum {
 pub fn parse_precursor_info(
     spectrum_path: &str,
 ) -> Result<HashMap<String, Precursor>, std::io::Error> {
-    mz_read!(spectrum_path.as_ref(), reader => {
-        reader.filter(|spectrum| spectrum.description.ms_level == 2)
-            .filter_map(|spectrum| {
-                spectrum.description.precursor.as_ref()?;
-                Some((spectrum.description.id.clone(), Precursor::from(&spectrum)))
-            })
-            .collect::<HashMap<String, Precursor>>()
-    })
+    let mut reader = MZReader::open_path(spectrum_path)?;
+    if let MZReader::ThermoRaw(inner) = &mut reader {
+        inner.set_centroiding(true);
+    }
+
+    Ok(reader
+        .filter(|spectrum| spectrum.description.ms_level == 2)
+        .filter_map(|spectrum| {
+            spectrum.description.precursor.as_ref()?;
+            Some((spectrum.description.id.clone(), Precursor::from(&spectrum)))
+        })
+        .collect::<HashMap<String, Precursor>>())
 }
 
 /// Read MS2 spectra from spectrum files with mzdata
-pub fn read_ms2_spectra(
-    spectrum_path: &str,
-) -> Result<Vec<MS2Spectrum>, std::io::Error> {
-    mz_read!(spectrum_path.as_ref(), reader => {
-        reader.filter(|spectrum| spectrum.description.ms_level == 2)
-            .map(MS2Spectrum::from)
-            .collect::<Vec<MS2Spectrum>>()
-    })
+pub fn read_ms2_spectra(spectrum_path: &str) -> Result<Vec<MS2Spectrum>, std::io::Error> {
+    let mut reader = MZReader::open_path(spectrum_path)?;
+    if let MZReader::ThermoRaw(inner) = &mut reader {
+        inner.set_centroiding(true);
+    }
+
+    Ok(reader
+        .filter(|spectrum| spectrum.description.ms_level == 2)
+        .map(MS2Spectrum::from)
+        .collect::<Vec<MS2Spectrum>>())
 }
 
 fn get_charge_from_spectrum(spectrum: &mzdata::spectrum::MultiLayerSpectrum) -> Option<usize> {

--- a/src/parse_mzdata.rs
+++ b/src/parse_mzdata.rs
@@ -48,11 +48,7 @@ impl From<mzdata::spectrum::MultiLayerSpectrum> for MS2Spectrum {
 pub fn parse_precursor_info(
     spectrum_path: &str,
 ) -> Result<HashMap<String, Precursor>, std::io::Error> {
-    let mut reader = MZReader::open_path(spectrum_path)?;
-    if let MZReader::ThermoRaw(inner) = &mut reader {
-        inner.set_centroiding(true);
-    }
-
+    let reader = MZReader::open_path(spectrum_path)?;
     Ok(reader
         .filter(|spectrum| spectrum.description.ms_level == 2)
         .filter_map(|spectrum| {

--- a/src/parse_timsrust.rs
+++ b/src/parse_timsrust.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use crate::ms2_spectrum::MS2Spectrum;
 use crate::precursor::Precursor;
 
-impl From<timsrust::ms_data::Precursor> for Precursor {
-    fn from(precursor: timsrust::ms_data::Precursor) -> Self {
+impl From<timsrust::Precursor> for Precursor {
+    fn from(precursor: timsrust::Precursor) -> Self {
         Precursor {
             mz: precursor.mz,
             rt: precursor.rt,
@@ -15,8 +15,8 @@ impl From<timsrust::ms_data::Precursor> for Precursor {
     }
 }
 
-impl From<timsrust::ms_data::Spectrum> for MS2Spectrum {
-    fn from(spectrum: timsrust::ms_data::Spectrum) -> Self {
+impl From<timsrust::Spectrum> for MS2Spectrum {
+    fn from(spectrum: timsrust::Spectrum) -> Self {
         MS2Spectrum::new(
             spectrum.index.to_string(),
             spectrum.mz_values.iter().map(|mz| *mz as f32).collect(),
@@ -25,7 +25,7 @@ impl From<timsrust::ms_data::Spectrum> for MS2Spectrum {
                 .iter()
                 .map(|intensity| *intensity as f32)
                 .collect(),
-            Some(Precursor::from(spectrum.precursor)),
+            spectrum.precursor.map(Precursor::from),
         )
     }
 }
@@ -34,35 +34,36 @@ impl From<timsrust::ms_data::Spectrum> for MS2Spectrum {
 pub fn parse_precursor_info(
     spectrum_path: &str,
 ) -> Result<HashMap<String, Precursor>, std::io::Error> {
-    let reader = timsrust::FileReader::new(spectrum_path)
+    let reader = timsrust::readers::SpectrumReader::new(spectrum_path)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
 
-    Ok(reader
-        .read_all_spectra()
+    let spectra = reader
+        .get_all()
         .into_iter()
-        .filter(|spectrum| {
-            matches!(
-                spectrum.precursor,
-                timsrust::ms_data::Precursor { .. }
-            )
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+
+    let precursor_info = spectra
+        .into_iter()
+        .filter_map(|spectrum| match spectrum.precursor {
+            Some(precursor) => Some((spectrum.index.to_string(), Precursor::from(precursor))),
+            None => None,
         })
-        .map(|spectrum| {
-            (
-                spectrum.index.to_string(),
-                Precursor::from(spectrum.precursor),
-            )
-        })
-        .collect::<HashMap<String, Precursor>>())
+        .collect::<HashMap<_, _>>();
+
+    Ok(precursor_info)
 }
 
 /// Read MS2 spectra from spectrum files with timsrust
 pub fn read_ms2_spectra(spectrum_path: &str) -> Result<Vec<MS2Spectrum>, std::io::Error> {
-    let reader = timsrust::FileReader::new(spectrum_path)
+    let reader = timsrust::readers::SpectrumReader::new(spectrum_path)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
 
-    Ok(reader
-        .read_all_spectra()
+    let spectra = reader
+        .get_all()
         .into_iter()
-        .map(MS2Spectrum::from)
-        .collect())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+
+    Ok(spectra.into_iter().map(MS2Spectrum::from).collect())
 }


### PR DESCRIPTION
### Changed

- Add `anyhow` feature for PyO3 for more detailed error messages

### Fixed

- Set vendor centroiding for thermo raw files, fixes reading of Thermo raw files that do not yet include centroided peaks.