### PR TITLE
update `mzdata` to 0.48.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ thermo = ["mzdata/thermo"]
 
 [dependencies]
 pyo3 = { version = "0.23.3", features = ["anyhow"] }
-mzdata = "0.39.0"
+mzdata = "0.48.3"
 timsrust = "0.4.1"


### PR DESCRIPTION
This upgrades the version of `mzdata` to 0.48.3, which includes more robust parsing of mzML metadata. Compared to the current version, this makes "invalid" values that aren't related to the integrity of spectra and signals warnings, not fatal errors. 

It also attempts to make use of the ion mobility accessors that handle things _other_ than timsTOF ion mobility measures. I saw you are handling some other non-standard names, but I don't recognize their origin.

I noticed that you use an unsigned integer type for charge state. In principle, that could lead to overflow when converting a signed integer to unsigned, so I also added an `abs` call prior to conversion to avoid catastrophic wrap around.