### PR TITLE
Fix reading gzipped MGFs and mzMLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,9 +1490,8 @@ dependencies = [
 
 [[package]]
 name = "mzdata"
-version = "0.59.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6c319f4111abe43bbcc33433b727968e30163f0a90e440386978656df8685c"
+version = "0.60.4"
+source = "git+https://github.com/mobiusklein/mzdata.git#99b9ddcba51680d428fa29eb3209a947683959bb"
 dependencies = [
  "base16ct",
  "base64-simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "ms2rescore-rs"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "mzdata",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,8 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "mzdata"
-version = "0.60.4"
-source = "git+https://github.com/mobiusklein/mzdata.git#99b9ddcba51680d428fa29eb3209a947683959bb"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87847d56fd9fe595b06459f1aec62143665f26051b7b30311b53fe89ed58c6cf"
 dependencies = [
  "base16ct",
  "base64-simd",
@@ -1809,12 +1810,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "37a6df7eab65fc7bee654a421404947e10a0f7085b6951bf2ea395f4659fb0cf"
 dependencies = [
  "anyhow",
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -1828,19 +1828,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "f77d387774f6f6eec64a004eac0ed525aab7fa1966d94b42f743797b3e395afb"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "2dd13844a4242793e02df3e2ec093f540d948299a6a77ea9ce7afd8623f542be"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1848,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "eaf8f9f1108270b90d3676b8679586385430e5c0bb78bb5f043f95499c821a71"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1860,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "70a3b2274450ba5288bc9b8c1b69ff569d1d61189d4bff38f8d22e03d17f932b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2358,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms2rescore-rs"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["cdylib"]
 default = []
 
 [dependencies]
-mzdata = { git = "https://github.com/mobiusklein/mzdata.git", features = ["thermo"] }
-pyo3 = { version = "0.23.3", features = ["anyhow"] }
+mzdata = { version = "0.61.0", features = ["thermo"] }
+pyo3 = { version = "0.27.0", features = ["anyhow"] }
 timsrust = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["cdylib"]
 default = []
 
 [dependencies]
-mzdata = { version = "0.59.2", features = ["thermo"] }
+mzdata = { git = "https://github.com/mobiusklein/mzdata.git", features = ["thermo"] }
 pyo3 = { version = "0.23.3", features = ["anyhow"] }
 timsrust = "0.4.1"

--- a/src/parse_mzdata.rs
+++ b/src/parse_mzdata.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fs::File;
 
 use mzdata::{params::ParamValue, prelude::*, MZReader};
 
@@ -48,7 +49,7 @@ impl From<mzdata::spectrum::MultiLayerSpectrum> for MS2Spectrum {
 pub fn parse_precursor_info(
     spectrum_path: &str,
 ) -> Result<HashMap<String, Precursor>, std::io::Error> {
-    let reader = MZReader::open_path(spectrum_path)?;
+    let reader = MZReader::<File>::open_read_seek_generic(Box::new(File::open(spectrum_path)?))?;
     Ok(reader
         .filter(|spectrum| spectrum.description.ms_level == 2)
         .filter_map(|spectrum| {
@@ -60,7 +61,7 @@ pub fn parse_precursor_info(
 
 /// Read MS2 spectra from spectrum files with mzdata
 pub fn read_ms2_spectra(spectrum_path: &str) -> Result<Vec<MS2Spectrum>, std::io::Error> {
-    let mut reader = MZReader::open_path(spectrum_path)?;
+    let mut reader = MZReader::<File>::open_read_seek_generic(Box::new(File::open(spectrum_path)?))?;
     if let MZReader::ThermoRaw(inner) = &mut reader {
         inner.set_centroiding(true);
     }


### PR DESCRIPTION
Use new `open_read_seek_generic` to fix support for gzipped MGs and mzMLs.