### PR TITLE
Add ms2pip feature vector and theoretical m/z computation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms2rescore-rs"
-version = "0.5.0-alpha.0"
+version = "0.5.0-alpha.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
+dependencies = ["numpy>=1.20"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -7,6 +7,7 @@ use rayon::prelude::*;
 
 use crate::types::annotation::{AnnotatedMS2Spectrum, FragmentAnnotation};
 use crate::types::ms2_spectrum::MS2Spectrum;
+use crate::utils::parse_ion_series_and_index;
 
 use ordered_float::OrderedFloat;
 use rustyms::annotation::model::FragmentationModel;
@@ -54,29 +55,6 @@ fn parse_tolerance(
     }
 }
 
-/// Parse an ion string like "b5", "y7", "c3", "z12", possibly with extra suffixes.
-/// Works on ASCII bytes to avoid heap allocations.
-fn parse_ion_series_and_index(ion: &str) -> Option<(char, usize)> {
-    let bytes = ion.trim().as_bytes();
-    if bytes.is_empty() {
-        return None;
-    }
-    let series = bytes[0] as char;
-    if !matches!(series, 'a' | 'b' | 'c' | 'x' | 'y' | 'z') {
-        return None;
-    }
-    let digit_end = bytes[1..]
-        .iter()
-        .position(|b| !b.is_ascii_digit())
-        .unwrap_or(bytes.len() - 1);
-    if digit_end == 0 {
-        return None;
-    }
-    // Safety: we verified these are ASCII digits
-    let digits = std::str::from_utf8(&bytes[1..1 + digit_end]).ok()?;
-    let idx = digits.parse::<usize>().ok()?;
-    Some((series, idx))
-}
 
 fn extract_fragment_charge(frag: &rustyms::fragment::Fragment) -> usize {
     frag.charge.value.unsigned_abs()

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -7,7 +7,7 @@ use rayon::prelude::*;
 
 use crate::types::annotation::{AnnotatedMS2Spectrum, FragmentAnnotation};
 use crate::types::ms2_spectrum::MS2Spectrum;
-use crate::utils::parse_ion_series_and_index;
+use crate::utils::parse_fragment;
 
 use ordered_float::OrderedFloat;
 use rustyms::annotation::model::FragmentationModel;
@@ -55,10 +55,6 @@ fn parse_tolerance(
     }
 }
 
-
-fn extract_fragment_charge(frag: &rustyms::fragment::Fragment) -> usize {
-    frag.charge.value.unsigned_abs()
-}
 
 /// Annotate MS2 spectra with theoretical fragment ions.
 #[pyfunction]
@@ -209,9 +205,7 @@ pub fn annotate_ms2_spectra(
                         peak.annotation
                             .iter()
                             .filter_map(|frag| {
-                                let ion_str = frag.ion.to_string();
-                                let (series, position) = parse_ion_series_and_index(&ion_str)?;
-                                let charge = extract_fragment_charge(frag);
+                                let (series, position, charge) = parse_fragment(frag)?;
                                 Some(FragmentAnnotation {
                                     series: series.to_string(),
                                     position,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,5 +27,13 @@ fn ms2rescore_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
         scoring::spectrum_prediction::ms2pip_features_from_prediction_peak_arrays,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(
+        ms2pip::feature_vectors::ms2pip_compute_features,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        ms2pip::theoretical_mz::ms2pip_compute_theoretical_mz,
+        m
+    )?)?;
     Ok(())
 }

--- a/src/ms2pip/feature_vectors.rs
+++ b/src/ms2pip/feature_vectors.rs
@@ -1,0 +1,396 @@
+use numpy::PyArray1;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use rayon::prelude::*;
+use rustyms::prelude::CompoundPeptidoformIon;
+
+/// Number of features per cleavage site.
+const N_FEATURES: usize = 139;
+
+/// Number of standard amino acids used in feature computation.
+const N_AA: usize = 19;
+
+/// AA single-letter codes in ms2pip index order.
+/// L is mapped to I (index 7).
+const AA_CHARS: [char; N_AA] = [
+    'A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W',
+    'Y',
+];
+
+/// 4 amino acid property tables, each indexed by AA index (0..18).
+/// Order: basicity, helicity, hydrophobicity, pI.
+const AA_PROPERTIES: [[u32; N_AA]; 4] = [
+    // Basicity
+    [37, 35, 59, 129, 94, 0, 210, 81, 191, 106, 101, 117, 115, 343, 49, 90, 60, 134, 104],
+    // Helicity
+    [68, 23, 33, 29, 70, 58, 41, 73, 32, 66, 38, 0, 40, 39, 44, 53, 71, 51, 55],
+    // Hydrophobicity
+    [51, 75, 25, 35, 100, 16, 3, 94, 0, 82, 12, 0, 22, 22, 21, 39, 80, 98, 70],
+    // pI (isoelectric point)
+    [32, 23, 0, 4, 27, 32, 48, 32, 69, 29, 26, 35, 28, 79, 29, 28, 31, 31, 28],
+];
+
+/// Map a single-letter AA code to its ms2pip index (0..18).
+/// L is mapped to I (index 7). Returns None for unknown AAs.
+fn aa_to_index(aa: char) -> Option<usize> {
+    match aa {
+        'A' => Some(0),
+        'C' => Some(1),
+        'D' => Some(2),
+        'E' => Some(3),
+        'F' => Some(4),
+        'G' => Some(5),
+        'H' => Some(6),
+        'I' | 'L' => Some(7),
+        'K' => Some(8),
+        'M' => Some(9),
+        'N' => Some(10),
+        'P' => Some(11),
+        'Q' => Some(12),
+        'R' => Some(13),
+        'S' => Some(14),
+        'T' => Some(15),
+        'V' => Some(16),
+        'W' => Some(17),
+        'Y' => Some(18),
+        _ => None,
+    }
+}
+
+/// Compute floor-based quartiles matching the C code.
+/// Input must be a sorted slice.
+fn quartiles(sorted: &[u32]) -> [u32; 5] {
+    let n = sorted.len();
+    if n == 0 {
+        return [0; 5];
+    }
+    if n == 1 {
+        return [sorted[0]; 5];
+    }
+    let q0 = sorted[0];
+    let q1 = sorted[((n - 1) as f64 * 0.25).floor() as usize];
+    let q2 = sorted[((n - 1) as f64 * 0.5).floor() as usize];
+    let q3 = sorted[((n - 1) as f64 * 0.75).floor() as usize];
+    let q4 = sorted[n - 1];
+    [q0, q1, q2, q3, q4]
+}
+
+/// Extract amino acid indices and charge from a ProForma string.
+/// Returns (aa_indices, charge). Modified residues are mapped to their base AA.
+fn parse_proforma(proforma: &str) -> Result<(Vec<usize>, usize), String> {
+    let compound = CompoundPeptidoformIon::pro_forma(proforma, None)
+        .map_err(|e| format!("Failed to parse ProForma '{proforma}': {e}"))?;
+
+    // Extract charge from the parsed peptidoform's charge carriers
+    let charge = compound
+        .peptidoforms()
+        .next()
+        .and_then(|pf| pf.get_charge_carriers())
+        .map(|cc| cc.charge().value.unsigned_abs())
+        .filter(|&c| c > 0)
+        .ok_or_else(|| format!("No charge state found in '{proforma}'. MS2PIP requires a charge (e.g. 'PEPTIDE/2')."))?;
+
+    // Extract amino acid sequence — must be exactly one peptidoform
+    let peptidoform_ions = compound.peptidoform_ions();
+    if peptidoform_ions.len() != 1 {
+        return Err(format!(
+            "Expected exactly 1 peptidoform ion in '{proforma}', found {}",
+            peptidoform_ions.len()
+        ));
+    }
+
+    let mut aa_indices = Vec::new();
+    for peptidoform in compound.peptidoforms() {
+        for pos in peptidoform.sequence() {
+            let aa = pos.aminoacid.aminoacid();
+            let aa_str = aa.to_string();
+            let aa_char = aa_str.chars().next().ok_or_else(|| {
+                format!("Empty amino acid string in '{proforma}'")
+            })?;
+            let idx = aa_to_index(aa_char).ok_or_else(|| {
+                format!("Unknown amino acid '{aa_char}' in '{proforma}'")
+            })?;
+            aa_indices.push(idx);
+        }
+    }
+
+    if aa_indices.is_empty() {
+        return Err(format!("No amino acids found in '{proforma}'"));
+    }
+
+    Ok((aa_indices, charge))
+}
+
+/// Compute 139 features for each cleavage site of a single peptide.
+/// Returns a flat Vec<f32> of length (peplen-1) * 139.
+fn compute_features_single(aa_indices: &[usize], charge: usize) -> Vec<f32> {
+    let peplen = aa_indices.len();
+    if peplen < 2 {
+        return Vec::new();
+    }
+
+    let n_ions = peplen - 1;
+    let mut features = vec![0.0_f32; n_ions * N_FEATURES];
+
+    // --- Shared peptide-level features (27 total) ---
+
+    // [0] p_length, [1] p_charge
+    let p_length = peplen as f32;
+    let p_charge = charge as f32;
+
+    // [2..6] charge one-hot
+    let charge_onehot: [f32; 5] = [
+        if charge == 1 { 1.0 } else { 0.0 },
+        if charge == 2 { 1.0 } else { 0.0 },
+        if charge == 3 { 1.0 } else { 0.0 },
+        if charge == 4 { 1.0 } else { 0.0 },
+        if charge >= 5 { 1.0 } else { 0.0 },
+    ];
+
+    // [7..26] peptide property quartiles (4 props × 5 quartiles)
+    let mut peptide_quartiles = [[0_u32; 5]; 4];
+    for prop_idx in 0..4 {
+        let mut prop_values: Vec<u32> = aa_indices
+            .iter()
+            .map(|&ai| AA_PROPERTIES[prop_idx][ai])
+            .collect();
+        prop_values.sort_unstable();
+        peptide_quartiles[prop_idx] = quartiles(&prop_values);
+    }
+
+    // --- Precompute per-property values for each position ---
+    let prop_at: Vec<[u32; 4]> = aa_indices
+        .iter()
+        .map(|&ai| {
+            [
+                AA_PROPERTIES[0][ai],
+                AA_PROPERTIES[1][ai],
+                AA_PROPERTIES[2][ai],
+                AA_PROPERTIES[3][ai],
+            ]
+        })
+        .collect();
+
+    // --- Precompute cumulative AA counts and property sums ---
+    // count_prefix[i][aa] = count of AA in positions 0..i (exclusive)
+    // prop_prefix[i][p] = sum of property p in positions 0..i (exclusive)
+    let mut count_prefix = vec![[0_u32; N_AA]; peplen + 1];
+    let mut prop_prefix = vec![[0_u32; 4]; peplen + 1];
+
+    for i in 0..peplen {
+        count_prefix[i + 1] = count_prefix[i];
+        count_prefix[i + 1][aa_indices[i]] += 1;
+
+        prop_prefix[i + 1] = prop_prefix[i];
+        for p in 0..4 {
+            prop_prefix[i + 1][p] += prop_at[i][p];
+        }
+    }
+
+    // --- Compute features per cleavage site ---
+    for ion_idx in 0..n_ions {
+        let offset = ion_idx * N_FEATURES;
+        let i = ion_idx; // Cleavage after position i (0-indexed)
+
+        // N-terminal ion: positions 0..=i (length i+1)
+        // C-terminal ion: positions i+1..peplen-1 (length peplen-1-i)
+        let n_len = (i + 1) as f32;
+        let c_len = (peplen - 1 - i) as f32;
+
+        // -- Shared features [0..26] --
+        features[offset] = p_length;
+        features[offset + 1] = p_charge;
+        for k in 0..5 {
+            features[offset + 2 + k] = charge_onehot[k];
+        }
+        for prop_idx in 0..4 {
+            for q in 0..5 {
+                features[offset + 7 + prop_idx * 5 + q] =
+                    peptide_quartiles[prop_idx][q] as f32;
+            }
+        }
+
+        // -- Ion lengths [27..28] --
+        features[offset + 27] = n_len;
+        features[offset + 28] = c_len;
+
+        // -- AA counts [29..66] --
+        // N-terminal: count in positions 0..=i → count_prefix[i+1]
+        // C-terminal: count in positions i+1..peplen → count_prefix[peplen] - count_prefix[i+1]
+        for aa in 0..N_AA {
+            let n_count = count_prefix[i + 1][aa];
+            let c_count = count_prefix[peplen][aa] - count_prefix[i + 1][aa];
+            features[offset + 29 + aa * 2] = n_count as f32;
+            features[offset + 29 + aa * 2 + 1] = c_count as f32;
+        }
+
+        // -- Property features [67..138] --
+        // 4 properties × 18 features each = 72 features
+        for prop_idx in 0..4 {
+            let prop_offset = offset + 67 + prop_idx * 18;
+
+            // Positional features (6):
+            // p0: first position of peptide
+            let p0 = prop_at[0][prop_idx] as f32;
+            // p-1: last position of peptide
+            let p_minus1 = prop_at[peplen - 1][prop_idx] as f32;
+            // pi-1: position before cleavage (or 0 if i==0)
+            let pi_minus1 = if i > 0 { prop_at[i - 1][prop_idx] as f32 } else { 0.0 };
+            // pi: cleavage position
+            let pi = prop_at[i][prop_idx] as f32;
+            // pi+1: position after cleavage
+            let pi_plus1 = prop_at[i + 1][prop_idx] as f32;
+            // pi+2: two positions after cleavage (or 0 if at end)
+            let pi_plus2 = if i + 2 < peplen {
+                prop_at[i + 2][prop_idx] as f32
+            } else {
+                0.0
+            };
+
+            features[prop_offset] = p0;
+            features[prop_offset + 1] = p_minus1;
+            features[prop_offset + 2] = pi_minus1;
+            features[prop_offset + 3] = pi;
+            features[prop_offset + 4] = pi_plus1;
+            features[prop_offset + 5] = pi_plus2;
+
+            // N-terminal ion: sum + quartiles (6)
+            let n_sum = prop_prefix[i + 1][prop_idx] as f32;
+            let mut n_props: Vec<u32> = (0..=i).map(|j| prop_at[j][prop_idx]).collect();
+            n_props.sort_unstable();
+            let n_q = quartiles(&n_props);
+
+            features[prop_offset + 6] = n_sum;
+            for q in 0..5 {
+                features[prop_offset + 7 + q] = n_q[q] as f32;
+            }
+
+            // C-terminal ion: sum + quartiles (6)
+            let c_sum = (prop_prefix[peplen][prop_idx] - prop_prefix[i + 1][prop_idx]) as f32;
+            let mut c_props: Vec<u32> = (i + 1..peplen).map(|j| prop_at[j][prop_idx]).collect();
+            c_props.sort_unstable();
+            let c_q = quartiles(&c_props);
+
+            features[prop_offset + 12] = c_sum;
+            for q in 0..5 {
+                features[prop_offset + 13 + q] = c_q[q] as f32;
+            }
+        }
+    }
+
+    features
+}
+
+/// Compute MS2PIP feature vectors for XGBoost prediction.
+///
+/// Takes ProForma strings with charge (e.g. "PEPTIDE/2") and returns
+/// a flat numpy array per peptide of length (n_ions * 139).
+/// Reshape to (n_ions, 139) on the Python side with n_ions = seq_len - 1.
+#[pyfunction]
+pub fn ms2pip_compute_features(
+    py: Python<'_>,
+    proformas: Vec<String>,
+) -> PyResult<Vec<Py<PyArray1<f32>>>> {
+    // Parse and compute in parallel (no GIL needed — pure Rust)
+    let results: Result<Vec<Vec<f32>>, String> = py.detach(|| {
+        proformas
+            .par_iter()
+            .enumerate()
+            .map(|(i, pf)| {
+                let (aa_indices, charge) = parse_proforma(pf)
+                    .map_err(|e| format!("ProForma at index {i}: {e}"))?;
+                Ok(compute_features_single(&aa_indices, charge))
+            })
+            .collect()
+    });
+
+    let results = results.map_err(PyValueError::new_err)?;
+
+    // Convert to numpy arrays (needs GIL)
+    let arrays: Vec<Py<PyArray1<f32>>> = results
+        .into_iter()
+        .map(|flat| PyArray1::from_vec(py, flat).into())
+        .collect();
+
+    Ok(arrays)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_aa_to_index() {
+        assert_eq!(aa_to_index('A'), Some(0));
+        assert_eq!(aa_to_index('L'), Some(7)); // L maps to I
+        assert_eq!(aa_to_index('I'), Some(7));
+        assert_eq!(aa_to_index('Y'), Some(18));
+        assert_eq!(aa_to_index('X'), None);
+    }
+
+    #[test]
+    fn test_quartiles() {
+        assert_eq!(quartiles(&[1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]);
+        assert_eq!(quartiles(&[10]), [10, 10, 10, 10, 10]);
+        assert_eq!(quartiles(&[]), [0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_compute_features_single_shape() {
+        // ACDE = 4 AA → 3 ions × 139 features = 417 values
+        let aa = vec![0, 1, 2, 3]; // A, C, D, E
+        let features = compute_features_single(&aa, 2);
+        assert_eq!(features.len(), 3 * N_FEATURES);
+    }
+
+    #[test]
+    fn test_compute_features_single_peptide_level() {
+        let aa = vec![0, 1, 2, 3]; // A, C, D, E, charge=2
+        let features = compute_features_single(&aa, 2);
+
+        // First ion's features
+        assert_eq!(features[0], 4.0); // p_length
+        assert_eq!(features[1], 2.0); // p_charge
+        assert_eq!(features[2], 0.0); // charge_1
+        assert_eq!(features[3], 1.0); // charge_2
+        assert_eq!(features[4], 0.0); // charge_3
+
+        // Check same shared features repeat for second ion
+        assert_eq!(features[N_FEATURES], 4.0); // p_length
+        assert_eq!(features[N_FEATURES + 1], 2.0); // p_charge
+    }
+
+    #[test]
+    fn test_compute_features_ion_lengths() {
+        let aa = vec![0, 1, 2, 3, 4]; // ACDEF, 4 ions
+        let features = compute_features_single(&aa, 2);
+
+        // Ion 0: n_len=1, c_len=4
+        assert_eq!(features[27], 1.0);
+        assert_eq!(features[28], 4.0);
+
+        // Ion 1: n_len=2, c_len=3
+        assert_eq!(features[N_FEATURES + 27], 2.0);
+        assert_eq!(features[N_FEATURES + 28], 3.0);
+
+        // Ion 3: n_len=4, c_len=1
+        assert_eq!(features[3 * N_FEATURES + 27], 4.0);
+        assert_eq!(features[3 * N_FEATURES + 28], 1.0);
+    }
+
+    #[test]
+    fn test_compute_features_short_peptide() {
+        // Minimum length: 2 AA → 1 ion
+        let aa = vec![0, 1]; // AC
+        let features = compute_features_single(&aa, 1);
+        assert_eq!(features.len(), N_FEATURES);
+    }
+
+    #[test]
+    fn test_compute_features_single_aa() {
+        // 1 AA → 0 ions → empty
+        let aa = vec![0];
+        let features = compute_features_single(&aa, 1);
+        assert!(features.is_empty());
+    }
+}

--- a/src/ms2pip/feature_vectors.rs
+++ b/src/ms2pip/feature_vectors.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 use rustyms::prelude::CompoundPeptidoformIon;
 
-use crate::utils::extract_charge;
+use crate::utils::{aa_to_ms2pip_index, extract_charge};
 
 /// Number of features per cleavage site.
 const N_FEATURES: usize = 139;
@@ -24,33 +24,6 @@ const AA_PROPERTIES: [[u32; N_AA]; 4] = [
     // pI (isoelectric point)
     [32, 23, 0, 4, 27, 32, 48, 32, 69, 29, 26, 35, 28, 79, 29, 28, 31, 31, 28],
 ];
-
-/// Map a single-letter AA code to its ms2pip index (0..18).
-/// L is mapped to I (index 7). Returns None for unknown AAs.
-fn aa_to_index(aa: char) -> Option<usize> {
-    match aa {
-        'A' => Some(0),
-        'C' => Some(1),
-        'D' => Some(2),
-        'E' => Some(3),
-        'F' => Some(4),
-        'G' => Some(5),
-        'H' => Some(6),
-        'I' | 'L' => Some(7),
-        'K' => Some(8),
-        'M' => Some(9),
-        'N' => Some(10),
-        'P' => Some(11),
-        'Q' => Some(12),
-        'R' => Some(13),
-        'S' => Some(14),
-        'T' => Some(15),
-        'V' => Some(16),
-        'W' => Some(17),
-        'Y' => Some(18),
-        _ => None,
-    }
-}
 
 /// Compute floor-based quartiles matching the C code.
 /// Input must be a sorted slice.
@@ -92,12 +65,8 @@ fn parse_proforma(proforma: &str) -> Result<(Vec<usize>, usize), String> {
     for peptidoform in compound.peptidoforms() {
         for pos in peptidoform.sequence() {
             let aa = pos.aminoacid.aminoacid();
-            let aa_str = aa.to_string();
-            let aa_char = aa_str.chars().next().ok_or_else(|| {
-                format!("Empty amino acid string in '{proforma}'")
-            })?;
-            let idx = aa_to_index(aa_char).ok_or_else(|| {
-                format!("Unknown amino acid '{aa_char}' in '{proforma}'")
+            let idx = aa_to_ms2pip_index(aa).ok_or_else(|| {
+                format!("Unsupported amino acid '{aa}' in '{proforma}'")
             })?;
             aa_indices.push(idx);
         }
@@ -307,15 +276,6 @@ pub fn ms2pip_compute_features(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_aa_to_index() {
-        assert_eq!(aa_to_index('A'), Some(0));
-        assert_eq!(aa_to_index('L'), Some(7)); // L maps to I
-        assert_eq!(aa_to_index('I'), Some(7));
-        assert_eq!(aa_to_index('Y'), Some(18));
-        assert_eq!(aa_to_index('X'), None);
-    }
 
     #[test]
     fn test_quartiles() {

--- a/src/ms2pip/feature_vectors.rs
+++ b/src/ms2pip/feature_vectors.rs
@@ -26,19 +26,21 @@ const AA_PROPERTIES: [[u32; N_AA]; 4] = [
 ];
 
 /// Compute floor-based quartiles matching the C code.
-/// Input must be a sorted slice.
-fn quartiles(sorted: &[u32]) -> [u32; 5] {
+/// Input must be a sorted slice. `denom` is the denominator used in the
+/// quantile index: `floor(q * denom)`. The C code uses different denominators
+/// for different contexts: `peplen-1` for peptide-level, `i` for N-ion
+/// (= n_elements - 1), and `peplen-i-1` for C-ion (= n_elements, NOT
+/// n_elements - 1). This inconsistency is a bug in the original C code but
+/// is intentionally replicated here for XGBoost model compatibility.
+fn quartiles_with_denom(sorted: &[u32], denom: usize) -> [u32; 5] {
     let n = sorted.len();
     if n == 0 {
         return [0; 5];
     }
-    if n == 1 {
-        return [sorted[0]; 5];
-    }
     let q0 = sorted[0];
-    let q1 = sorted[((n - 1) as f64 * 0.25).floor() as usize];
-    let q2 = sorted[((n - 1) as f64 * 0.5).floor() as usize];
-    let q3 = sorted[((n - 1) as f64 * 0.75).floor() as usize];
+    let q1 = sorted[((denom as f64 * 0.25).floor() as usize).min(n - 1)];
+    let q2 = sorted[((denom as f64 * 0.5).floor() as usize).min(n - 1)];
+    let q3 = sorted[((denom as f64 * 0.75).floor() as usize).min(n - 1)];
     let q4 = sorted[n - 1];
     [q0, q1, q2, q3, q4]
 }
@@ -113,7 +115,7 @@ fn compute_features_single(aa_indices: &[usize], charge: usize) -> Vec<f32> {
             .map(|&ai| AA_PROPERTIES[prop_idx][ai])
             .collect();
         prop_values.sort_unstable();
-        peptide_quartiles[prop_idx] = quartiles(&prop_values);
+        peptide_quartiles[prop_idx] = quartiles_with_denom(&prop_values, peplen - 1);
     }
 
     // --- Precompute per-property values for each position ---
@@ -146,14 +148,41 @@ fn compute_features_single(aa_indices: &[usize], charge: usize) -> Vec<f32> {
     }
 
     // --- Compute features per cleavage site ---
+    // The C code uses 1-indexed peptide_buf where peptide_buf[0] = nterm_mod.
+    // For unmodified peptides, peptide_buf[0] = 0, so props[j][0] = AA index 0's
+    // property (Alanine). We replicate this with a "virtual" position -1 that maps
+    // to AA index 0. The positional features pi-1, pi, pi+1, pi+2 in the C code
+    // reference peptide_buf[i-1], peptide_buf[i], peptide_buf[i+1], peptide_buf[i+2]
+    // where i is 0-indexed and peptide_buf is 1-indexed.
+    //
+    // The C code also uses an incremental count_c that starts as the full peptide
+    // and removes from the RIGHT end (position peplen-i in 1-indexed = peplen-1-i
+    // in 0-indexed) at each step.
+
+    // Build prop_at_buf matching C's peptide_buf: [nterm_prop, aa0_prop, aa1_prop, ...]
+    // C code bug: peptide_buf[0] = nterm_mod = 0 for unmodified peptides, so
+    // props[j][peptide_buf[0]] = props[j][0] = Alanine's property, regardless of
+    // the actual first residue. This is used for positional feature pi when i=0.
+    // Intentionally replicated for XGBoost model compatibility.
+    let prop_at_buf: Vec<[u32; 4]> = std::iter::once([
+        AA_PROPERTIES[0][0],
+        AA_PROPERTIES[1][0],
+        AA_PROPERTIES[2][0],
+        AA_PROPERTIES[3][0],
+    ])
+    .chain(prop_at.iter().copied())
+    .collect();
+
+    // Incremental c AA counts (matching C code: start full, remove from right)
+    let mut inc_count_n = [0_u32; N_AA];
+    let mut inc_count_c = [0_u32; N_AA];
+    for &ai in aa_indices {
+        inc_count_c[ai] += 1;
+    }
+
     for ion_idx in 0..n_ions {
         let offset = ion_idx * N_FEATURES;
-        let i = ion_idx; // Cleavage after position i (0-indexed)
-
-        // N-terminal ion: positions 0..=i (length i+1)
-        // C-terminal ion: positions i+1..peplen-1 (length peplen-1-i)
-        let n_len = (i + 1) as f32;
-        let c_len = (peplen - 1 - i) as f32;
+        let i = ion_idx;
 
         // -- Shared features [0..26] --
         features[offset] = p_length;
@@ -169,40 +198,43 @@ fn compute_features_single(aa_indices: &[usize], charge: usize) -> Vec<f32> {
         }
 
         // -- Ion lengths [27..28] --
-        features[offset + 27] = n_len;
-        features[offset + 28] = c_len;
+        // C code: v[fnum++] = i+1; v[fnum++] = peplen-i;
+        features[offset + 27] = (i + 1) as f32;
+        features[offset + 28] = (peplen - i) as f32;
 
         // -- AA counts [29..66] --
-        // N-terminal: count in positions 0..=i → count_prefix[i+1]
-        // C-terminal: count in positions i+1..peplen → count_prefix[peplen] - count_prefix[i+1]
+        // C code updates counts BEFORE writing them:
+        // count_n[peptide_buf[i+1]]++ → add position i (0-indexed)
+        // count_c[peptide_buf[peplen-i]]-- → remove position peplen-1-i (0-indexed)
+        inc_count_n[aa_indices[i]] += 1;
+        inc_count_c[aa_indices[peplen - 1 - i]] -= 1;
+
         for aa in 0..N_AA {
-            let n_count = count_prefix[i + 1][aa];
-            let c_count = count_prefix[peplen][aa] - count_prefix[i + 1][aa];
-            features[offset + 29 + aa * 2] = n_count as f32;
-            features[offset + 29 + aa * 2 + 1] = c_count as f32;
+            features[offset + 29 + aa * 2] = inc_count_n[aa] as f32;
+            features[offset + 29 + aa * 2 + 1] = inc_count_c[aa] as f32;
         }
 
         // -- Property features [67..138] --
-        // 4 properties × 18 features each = 72 features
         for prop_idx in 0..4 {
             let prop_offset = offset + 67 + prop_idx * 18;
 
-            // Positional features (6):
-            // p0: first position of peptide
-            let p0 = prop_at[0][prop_idx] as f32;
-            // p-1: last position of peptide
-            let p_minus1 = prop_at[peplen - 1][prop_idx] as f32;
-            // pi-1: position before cleavage (or 0 if i==0)
-            let pi_minus1 = if i > 0 { prop_at[i - 1][prop_idx] as f32 } else { 0.0 };
-            // pi: cleavage position
-            let pi = prop_at[i][prop_idx] as f32;
-            // pi+1: position after cleavage
-            let pi_plus1 = prop_at[i + 1][prop_idx] as f32;
-            // pi+2: two positions after cleavage (or 0 if at end)
-            let pi_plus2 = if i + 2 < peplen {
-                prop_at[i + 2][prop_idx] as f32
-            } else {
+            // Positional features (6) — using prop_at_buf (1-indexed like C)
+            // C code: props[j][peptide_buf[1]], props[j][peptide_buf[peplen]],
+            //         props[j][peptide_buf[i-1]] (or 0), props[j][peptide_buf[i]],
+            //         props[j][peptide_buf[i+1]], props[j][peptide_buf[i+2]] (or 0)
+            let p0 = prop_at_buf[1][prop_idx] as f32;
+            let p_minus1 = prop_at_buf[peplen][prop_idx] as f32;
+            let pi_minus1 = if i == 0 {
                 0.0
+            } else {
+                prop_at_buf[i - 1][prop_idx] as f32 // peptide_buf[i-1]
+            };
+            let pi = prop_at_buf[i][prop_idx] as f32; // peptide_buf[i]
+            let pi_plus1 = prop_at_buf[i + 1][prop_idx] as f32; // peptide_buf[i+1]
+            let pi_plus2 = if i == peplen - 1 {
+                0.0
+            } else {
+                prop_at_buf[i + 2][prop_idx] as f32 // peptide_buf[i+2]
             };
 
             features[prop_offset] = p0;
@@ -213,23 +245,29 @@ fn compute_features_single(aa_indices: &[usize], charge: usize) -> Vec<f32> {
             features[prop_offset + 5] = pi_plus2;
 
             // N-terminal ion: sum + quartiles (6)
-            let n_sum = prop_prefix[i + 1][prop_idx] as f32;
+            // C code: positions 0..=i (0-indexed), denom for quartiles = i
             let mut n_props: Vec<u32> = (0..=i).map(|j| prop_at[j][prop_idx]).collect();
+            let n_sum: u32 = n_props.iter().sum();
             n_props.sort_unstable();
-            let n_q = quartiles(&n_props);
+            let n_q = quartiles_with_denom(&n_props, i);
 
-            features[prop_offset + 6] = n_sum;
+            features[prop_offset + 6] = n_sum as f32;
             for q in 0..5 {
                 features[prop_offset + 7 + q] = n_q[q] as f32;
             }
 
             // C-terminal ion: sum + quartiles (6)
-            let c_sum = (prop_prefix[peplen][prop_idx] - prop_prefix[i + 1][prop_idx]) as f32;
-            let mut c_props: Vec<u32> = (i + 1..peplen).map(|j| prop_at[j][prop_idx]).collect();
+            // C code: positions i+1..peplen-1 (0-indexed).
+            // C code bug: denom = peplen-i-1 = n_elements, while peptide-level
+            // and N-ion use n_elements-1. Intentionally replicated for model compat.
+            let c_n_elements = peplen - i - 1;
+            let mut c_props: Vec<u32> =
+                (i + 1..peplen).map(|j| prop_at[j][prop_idx]).collect();
+            let c_sum: u32 = c_props.iter().sum();
             c_props.sort_unstable();
-            let c_q = quartiles(&c_props);
+            let c_q = quartiles_with_denom(&c_props, c_n_elements);
 
-            features[prop_offset + 12] = c_sum;
+            features[prop_offset + 12] = c_sum as f32;
             for q in 0..5 {
                 features[prop_offset + 13 + q] = c_q[q] as f32;
             }
@@ -278,58 +316,78 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_quartiles() {
-        assert_eq!(quartiles(&[1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]);
-        assert_eq!(quartiles(&[10]), [10, 10, 10, 10, 10]);
-        assert_eq!(quartiles(&[]), [0, 0, 0, 0, 0]);
+    fn test_quartiles_with_denom() {
+        // peplen-1 formula: denom = n-1
+        assert_eq!(
+            quartiles_with_denom(&[1, 2, 3, 4, 5], 4),
+            [1, 2, 3, 4, 5]
+        );
+        assert_eq!(quartiles_with_denom(&[10], 0), [10, 10, 10, 10, 10]);
+        assert_eq!(quartiles_with_denom(&[], 0), [0, 0, 0, 0, 0]);
     }
 
     #[test]
     fn test_compute_features_single_shape() {
-        // ACDE = 4 AA → 3 ions × 139 features = 417 values
-        let aa = vec![0, 1, 2, 3]; // A, C, D, E
+        let aa = vec![0, 1, 2, 3]; // ACDE
         let features = compute_features_single(&aa, 2);
         assert_eq!(features.len(), 3 * N_FEATURES);
     }
 
     #[test]
     fn test_compute_features_single_peptide_level() {
-        let aa = vec![0, 1, 2, 3]; // A, C, D, E, charge=2
+        let aa = vec![0, 1, 2, 3]; // ACDE, charge=2
         let features = compute_features_single(&aa, 2);
-
-        // First ion's features
         assert_eq!(features[0], 4.0); // p_length
         assert_eq!(features[1], 2.0); // p_charge
         assert_eq!(features[2], 0.0); // charge_1
         assert_eq!(features[3], 1.0); // charge_2
-        assert_eq!(features[4], 0.0); // charge_3
-
-        // Check same shared features repeat for second ion
-        assert_eq!(features[N_FEATURES], 4.0); // p_length
-        assert_eq!(features[N_FEATURES + 1], 2.0); // p_charge
+        // Same shared features for all ions
+        assert_eq!(features[N_FEATURES], 4.0);
+        assert_eq!(features[N_FEATURES + 1], 2.0);
     }
 
     #[test]
     fn test_compute_features_ion_lengths() {
-        let aa = vec![0, 1, 2, 3, 4]; // ACDEF, 4 ions
+        let aa = vec![0, 1, 2, 3, 4]; // ACDEF (5 AAs, 4 ions)
+        let features = compute_features_single(&aa, 2);
+        // C code: n_len = i+1, c_len = peplen-i
+        assert_eq!(features[27], 1.0); // ion 0: n=1
+        assert_eq!(features[28], 5.0); // ion 0: c=5
+        assert_eq!(features[N_FEATURES + 27], 2.0); // ion 1: n=2
+        assert_eq!(features[N_FEATURES + 28], 4.0); // ion 1: c=4
+        assert_eq!(features[3 * N_FEATURES + 27], 4.0); // ion 3: n=4
+        assert_eq!(features[3 * N_FEATURES + 28], 2.0); // ion 3: c=2
+    }
+
+    #[test]
+    fn test_compute_features_c_reference_acde() {
+        // Exact reference values from C code for ACDE/2
+        let aa = vec![0, 1, 2, 3]; // A, C, D, E
         let features = compute_features_single(&aa, 2);
 
-        // Ion 0: n_len=1, c_len=4
-        assert_eq!(features[27], 1.0);
-        assert_eq!(features[28], 4.0);
+        let expected_ion0: Vec<f32> = vec![
+            4, 2, 0, 1, 0, 0, 0, 35, 35, 37, 59, 129, 23, 23, 29, 33, 68, 25, 25,
+            35, 51, 75, 0, 0, 4, 23, 32, 1, 4, 1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 37, 129, 0, 37, 37, 35, 37, 37, 37, 37, 37, 37, 223, 35, 35,
+            59, 129, 129, 68, 29, 0, 68, 68, 23, 68, 68, 68, 68, 68, 68, 85, 23, 23,
+            29, 33, 33, 51, 35, 0, 51, 51, 75, 51, 51, 51, 51, 51, 51, 135, 25, 25,
+            35, 75, 75, 32, 4, 0, 32, 32, 23, 32, 32, 32, 32, 32, 32, 27, 0, 0, 4,
+            23, 23,
+        ]
+        .into_iter()
+        .map(|x| x as f32)
+        .collect();
 
-        // Ion 1: n_len=2, c_len=3
-        assert_eq!(features[N_FEATURES + 27], 2.0);
-        assert_eq!(features[N_FEATURES + 28], 3.0);
-
-        // Ion 3: n_len=4, c_len=1
-        assert_eq!(features[3 * N_FEATURES + 27], 4.0);
-        assert_eq!(features[3 * N_FEATURES + 28], 1.0);
+        let ion0 = &features[..N_FEATURES];
+        assert_eq!(ion0.len(), expected_ion0.len());
+        for (idx, (&got, &exp)) in ion0.iter().zip(expected_ion0.iter()).enumerate() {
+            assert_eq!(got, exp, "Ion 0, feature {idx}: got {got}, expected {exp}");
+        }
     }
 
     #[test]
     fn test_compute_features_short_peptide() {
-        // Minimum length: 2 AA → 1 ion
         let aa = vec![0, 1]; // AC
         let features = compute_features_single(&aa, 1);
         assert_eq!(features.len(), N_FEATURES);
@@ -337,7 +395,6 @@ mod tests {
 
     #[test]
     fn test_compute_features_single_aa() {
-        // 1 AA → 0 ions → empty
         let aa = vec![0];
         let features = compute_features_single(&aa, 1);
         assert!(features.is_empty());

--- a/src/ms2pip/feature_vectors.rs
+++ b/src/ms2pip/feature_vectors.rs
@@ -4,6 +4,8 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 use rustyms::prelude::CompoundPeptidoformIon;
 
+use crate::utils::extract_charge;
+
 /// Number of features per cleavage site.
 const N_FEATURES: usize = 139;
 
@@ -81,13 +83,7 @@ fn parse_proforma(proforma: &str) -> Result<(Vec<usize>, usize), String> {
     let compound = CompoundPeptidoformIon::pro_forma(proforma, None)
         .map_err(|e| format!("Failed to parse ProForma '{proforma}': {e}"))?;
 
-    // Extract charge from the parsed peptidoform's charge carriers
-    let charge = compound
-        .peptidoforms()
-        .next()
-        .and_then(|pf| pf.get_charge_carriers())
-        .map(|cc| cc.charge().value.unsigned_abs())
-        .filter(|&c| c > 0)
+    let charge = extract_charge(&compound)
         .ok_or_else(|| format!("No charge state found in '{proforma}'. MS2PIP requires a charge (e.g. 'PEPTIDE/2')."))?;
 
     // Extract amino acid sequence — must be exactly one peptidoform

--- a/src/ms2pip/feature_vectors.rs
+++ b/src/ms2pip/feature_vectors.rs
@@ -12,13 +12,6 @@ const N_FEATURES: usize = 139;
 /// Number of standard amino acids used in feature computation.
 const N_AA: usize = 19;
 
-/// AA single-letter codes in ms2pip index order.
-/// L is mapped to I (index 7).
-const AA_CHARS: [char; N_AA] = [
-    'A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W',
-    'Y',
-];
-
 /// 4 amino acid property tables, each indexed by AA index (0..18).
 /// Order: basicity, helicity, hydrophobicity, pI.
 const AA_PROPERTIES: [[u32; N_AA]; 4] = [

--- a/src/ms2pip/mod.rs
+++ b/src/ms2pip/mod.rs
@@ -1,1 +1,2 @@
-// Future: XGBoost feature vector computation for ms2pip
+pub mod feature_vectors;
+pub mod theoretical_mz;

--- a/src/ms2pip/theoretical_mz.rs
+++ b/src/ms2pip/theoretical_mz.rs
@@ -7,27 +7,7 @@ use rayon::prelude::*;
 use rustyms::prelude::CompoundPeptidoformIon;
 
 use crate::annotation::{parse_fragmentation_model, parse_mass_mode};
-use crate::utils::{extract_charge, parse_ion_series_and_index};
-
-/// Map a rustyms Fragment to its ms2pip ion type string (e.g. "b", "y", "b2").
-/// Returns None for non-backbone ions.
-fn fragment_ion_type(frag: &rustyms::fragment::Fragment) -> Option<String> {
-    let ion_str = frag.ion.to_string();
-    let (series, _) = parse_ion_series_and_index(&ion_str)?;
-    let charge = frag.charge.value.unsigned_abs();
-    if charge <= 1 {
-        Some(series.to_string())
-    } else {
-        Some(format!("{series}{charge}"))
-    }
-}
-
-/// Extract the 1-indexed ion position from a fragment.
-fn fragment_position(frag: &rustyms::fragment::Fragment) -> Option<usize> {
-    let ion_str = frag.ion.to_string();
-    let (_, position) = parse_ion_series_and_index(&ion_str)?;
-    Some(position)
-}
+use crate::utils::{extract_charge, parse_fragment};
 
 /// Compute theoretical m/z values for fragment ions.
 ///
@@ -79,20 +59,27 @@ pub fn ms2pip_compute_theoretical_mz(
                     .collect();
 
                 for frag in &frags {
-                    let ion_type = match fragment_ion_type(frag) {
-                        Some(it) if mz_map.contains_key(&it) => it,
-                        _ => continue,
-                    };
-                    let position = match fragment_position(frag) {
-                        Some(p) if p >= 1 && p <= n_ions => p,
-                        _ => continue,
+                    let (series, position, frag_charge) = match parse_fragment(frag) {
+                        Some(info) => info,
+                        None => continue,
                     };
 
-                    if let Some(mz) = frag.mz(mode) {
+                    if position < 1 || position > n_ions {
+                        continue;
+                    }
+
+                    let ion_key = if frag_charge <= 1 {
+                        series.to_string()
+                    } else {
+                        format!("{series}{frag_charge}")
+                    };
+
+                    if let Some(arr) = mz_map.get_mut(&ion_key) {
                         let idx = position - 1;
-                        let arr = mz_map.get_mut(&ion_type).unwrap();
-                        if arr[idx] == 0.0 {
-                            arr[idx] = mz.value;
+                        if let Some(mz) = frag.mz(mode) {
+                            if arr[idx] == 0.0 {
+                                arr[idx] = mz.value;
+                            }
                         }
                     }
                 }

--- a/src/ms2pip/theoretical_mz.rs
+++ b/src/ms2pip/theoretical_mz.rs
@@ -1,0 +1,1 @@
+// Theoretical m/z computation — implemented in Step 2.

--- a/src/ms2pip/theoretical_mz.rs
+++ b/src/ms2pip/theoretical_mz.rs
@@ -1,1 +1,107 @@
-// Theoretical m/z computation — implemented in Step 2.
+use std::collections::HashMap;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use rayon::prelude::*;
+
+use rustyms::chemistry::MassMode;
+use rustyms::prelude::CompoundPeptidoformIon;
+
+use crate::annotation::{parse_fragmentation_model, parse_mass_mode};
+use crate::utils::{extract_charge, parse_ion_series_and_index};
+
+/// Map a rustyms Fragment to its ms2pip ion type string (e.g. "b", "y", "b2").
+/// Returns None for non-backbone ions.
+fn fragment_ion_type(frag: &rustyms::fragment::Fragment) -> Option<String> {
+    let ion_str = frag.ion.to_string();
+    let (series, _) = parse_ion_series_and_index(&ion_str)?;
+    let charge = frag.charge.value.unsigned_abs();
+    if charge <= 1 {
+        Some(series.to_string())
+    } else {
+        Some(format!("{series}{charge}"))
+    }
+}
+
+/// Extract the 1-indexed ion position from a fragment.
+fn fragment_position(frag: &rustyms::fragment::Fragment) -> Option<usize> {
+    let ion_str = frag.ion.to_string();
+    let (_, position) = parse_ion_series_and_index(&ion_str)?;
+    Some(position)
+}
+
+/// Compute theoretical m/z values for fragment ions.
+///
+/// Uses rustyms fragment generation, consistent with `annotate_ms2_spectra`.
+/// Returns a dict mapping ion type (e.g. "b", "y", "b2") to a list of m/z
+/// values ordered by ion position, length = seq_len - 1.
+#[pyfunction]
+pub fn ms2pip_compute_theoretical_mz(
+    py: Python<'_>,
+    proformas: Vec<String>,
+    ion_types: Vec<String>,
+    fragmentation_model: String,
+    mass_mode: String,
+) -> PyResult<Vec<HashMap<String, Vec<f64>>>> {
+    let model = parse_fragmentation_model(&fragmentation_model)?;
+    let mode = parse_mass_mode(&mass_mode)?;
+
+    let results: Result<Vec<HashMap<String, Vec<f64>>>, String> = py.detach(|| {
+        proformas
+            .par_iter()
+            .enumerate()
+            .map(|(i, pf)| {
+                let compound = CompoundPeptidoformIon::pro_forma(pf, None)
+                    .map_err(|e| format!("ProForma at index {i}: {e}"))?;
+
+                let charge = extract_charge(&compound).unwrap_or(1) as isize;
+
+                let seq_len = compound
+                    .peptidoforms()
+                    .next()
+                    .map(|pf| pf.sequence().len())
+                    .unwrap_or(0);
+
+                if seq_len < 2 {
+                    return Ok(ion_types
+                        .iter()
+                        .map(|it| (it.clone(), Vec::new()))
+                        .collect());
+                }
+
+                let n_ions = seq_len - 1;
+                let frag_charge =
+                    rustyms::system::isize::Charge::new::<rustyms::system::e>(charge);
+                let frags = compound.generate_theoretical_fragments(frag_charge, &model);
+
+                let mut mz_map: HashMap<String, Vec<f64>> = ion_types
+                    .iter()
+                    .map(|it| (it.clone(), vec![0.0; n_ions]))
+                    .collect();
+
+                for frag in &frags {
+                    let ion_type = match fragment_ion_type(frag) {
+                        Some(it) if mz_map.contains_key(&it) => it,
+                        _ => continue,
+                    };
+                    let position = match fragment_position(frag) {
+                        Some(p) if p >= 1 && p <= n_ions => p,
+                        _ => continue,
+                    };
+
+                    if let Some(mz) = frag.mz(mode) {
+                        let idx = position - 1;
+                        let arr = mz_map.get_mut(&ion_type).unwrap();
+                        if arr[idx] == 0.0 {
+                            arr[idx] = mz.value;
+                        }
+                    }
+                }
+
+                Ok(mz_map)
+            })
+            .collect()
+    });
+
+    results.map_err(|e| PyValueError::new_err(e))
+}

--- a/src/ms2pip/theoretical_mz.rs
+++ b/src/ms2pip/theoretical_mz.rs
@@ -4,7 +4,6 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
-use rustyms::chemistry::MassMode;
 use rustyms::prelude::CompoundPeptidoformIon;
 
 use crate::annotation::{parse_fragmentation_model, parse_mass_mode};
@@ -103,5 +102,5 @@ pub fn ms2pip_compute_theoretical_mz(
             .collect()
     });
 
-    results.map_err(|e| PyValueError::new_err(e))
+    results.map_err(PyValueError::new_err)
 }

--- a/src/types/annotation.rs
+++ b/src/types/annotation.rs
@@ -31,6 +31,16 @@ impl FragmentAnnotation {
             self.series, self.position, self.charge
         )
     }
+
+    pub fn __reduce__(
+        &self,
+        py: Python<'_>,
+    ) -> PyResult<(Py<PyAny>, (String, usize, usize))> {
+        let cls = py
+            .import("ms2rescore_rs")?
+            .getattr("FragmentAnnotation")?;
+        Ok((cls.into(), (self.series.clone(), self.position, self.charge)))
+    }
 }
 
 /// An MS2 spectrum annotated with fragment ion assignments.
@@ -86,5 +96,33 @@ impl AnnotatedMS2Spectrum {
             self.mz.len(),
             n_annotated
         )
+    }
+
+    pub fn __reduce__(
+        &self,
+        py: Python<'_>,
+    ) -> PyResult<(
+        Py<PyAny>,
+        (
+            String,
+            Vec<f32>,
+            Vec<f32>,
+            Option<Precursor>,
+            Vec<Vec<FragmentAnnotation>>,
+        ),
+    )> {
+        let cls = py
+            .import("ms2rescore_rs")?
+            .getattr("AnnotatedMS2Spectrum")?;
+        Ok((
+            cls.into(),
+            (
+                self.identifier.clone(),
+                self.mz.clone(),
+                self.intensity.clone(),
+                self.precursor.clone(),
+                self.peak_annotations.clone(),
+            ),
+        ))
     }
 }

--- a/src/types/annotation.rs
+++ b/src/types/annotation.rs
@@ -2,6 +2,14 @@ use pyo3::prelude::*;
 
 use crate::types::precursor::Precursor;
 
+type AnnotatedMS2SpectrumReduceArgs = (
+    String,
+    Vec<f32>,
+    Vec<f32>,
+    Option<Precursor>,
+    Vec<Vec<FragmentAnnotation>>,
+);
+
 /// A single fragment annotation on a peak.
 #[pyclass(module = "ms2rescore_rs", get_all, from_py_object)]
 #[derive(Debug, Clone)]
@@ -101,16 +109,7 @@ impl AnnotatedMS2Spectrum {
     pub fn __reduce__(
         &self,
         py: Python<'_>,
-    ) -> PyResult<(
-        Py<PyAny>,
-        (
-            String,
-            Vec<f32>,
-            Vec<f32>,
-            Option<Precursor>,
-            Vec<Vec<FragmentAnnotation>>,
-        ),
-    )> {
+    ) -> PyResult<(Py<PyAny>, AnnotatedMS2SpectrumReduceArgs)> {
         let cls = py
             .import("ms2rescore_rs")?
             .getattr("AnnotatedMS2Spectrum")?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,6 @@
+use rustyms::fragment::{Fragment, FragmentType};
 use rustyms::prelude::CompoundPeptidoformIon;
+use rustyms::sequence::AminoAcid;
 
 /// Compute ln(n!). For typical peptide-length inputs (n < 50) the
 /// iterative sum is fast enough; a lookup table is not warranted.
@@ -6,28 +8,21 @@ pub fn ln_factorial(n: usize) -> f64 {
     (1..=n).map(|k| (k as f64).ln()).sum()
 }
 
-/// Parse an ion string like "b5", "y7", "c3", "z12" into (series, position).
-/// Works on ASCII bytes to avoid heap allocations.
-/// Supports all 6 primary ion series: a, b, c, x, y, z.
-pub fn parse_ion_series_and_index(ion: &str) -> Option<(char, usize)> {
-    let bytes = ion.trim().as_bytes();
-    if bytes.is_empty() {
-        return None;
-    }
-    let series = bytes[0] as char;
-    if !matches!(series, 'a' | 'b' | 'c' | 'x' | 'y' | 'z') {
-        return None;
-    }
-    let digit_end = bytes[1..]
-        .iter()
-        .position(|b| !b.is_ascii_digit())
-        .unwrap_or(bytes.len() - 1);
-    if digit_end == 0 {
-        return None;
-    }
-    let digits = std::str::from_utf8(&bytes[1..1 + digit_end]).ok()?;
-    let idx = digits.parse::<usize>().ok()?;
-    Some((series, idx))
+/// Parse a rustyms Fragment into (series_char, position, charge).
+/// Returns None for non-backbone ions (glycan, immonium, precursor, etc.).
+/// Position is 1-indexed (the series_number from rustyms).
+pub fn parse_fragment(frag: &Fragment) -> Option<(char, usize, usize)> {
+    let (series, pos) = match &frag.ion {
+        FragmentType::a(pos, _) => ('a', pos),
+        FragmentType::b(pos, _) => ('b', pos),
+        FragmentType::c(pos, _) => ('c', pos),
+        FragmentType::x(pos, _) => ('x', pos),
+        FragmentType::y(pos, _) => ('y', pos),
+        FragmentType::z(pos, _) => ('z', pos),
+        _ => return None,
+    };
+    let charge = frag.charge.value.unsigned_abs();
+    Some((series, pos.series_number, charge))
 }
 
 /// Extract the precursor charge from a parsed CompoundPeptidoformIon.
@@ -39,6 +34,33 @@ pub fn extract_charge(compound: &CompoundPeptidoformIon) -> Option<usize> {
         .and_then(|pf| pf.get_charge_carriers())
         .map(|cc| cc.charge().value.unsigned_abs())
         .filter(|&c| c > 0)
+}
+
+/// Map a rustyms AminoAcid to its ms2pip index (0..18).
+/// L is mapped to I (index 7). Returns None for non-standard AAs.
+pub fn aa_to_ms2pip_index(aa: AminoAcid) -> Option<usize> {
+    match aa {
+        AminoAcid::Alanine => Some(0),
+        AminoAcid::Cysteine => Some(1),
+        AminoAcid::AsparticAcid => Some(2),
+        AminoAcid::GlutamicAcid => Some(3),
+        AminoAcid::Phenylalanine => Some(4),
+        AminoAcid::Glycine => Some(5),
+        AminoAcid::Histidine => Some(6),
+        AminoAcid::Isoleucine | AminoAcid::Leucine | AminoAcid::AmbiguousLeucine => Some(7),
+        AminoAcid::Lysine => Some(8),
+        AminoAcid::Methionine => Some(9),
+        AminoAcid::Asparagine => Some(10),
+        AminoAcid::Proline => Some(11),
+        AminoAcid::Glutamine => Some(12),
+        AminoAcid::Arginine => Some(13),
+        AminoAcid::Serine => Some(14),
+        AminoAcid::Threonine => Some(15),
+        AminoAcid::Valine => Some(16),
+        AminoAcid::Tryptophan => Some(17),
+        AminoAcid::Tyrosine => Some(18),
+        _ => None,
+    }
 }
 
 /// Compute the longest run of `true` values in a boolean slice.
@@ -74,5 +96,14 @@ mod tests {
         assert_eq!(longest_true_run(&[true, true, false, true]), 2);
         assert_eq!(longest_true_run(&[true, true, true]), 3);
         assert_eq!(longest_true_run(&[false, true, false, true, true, false]), 2);
+    }
+
+    #[test]
+    fn test_aa_to_ms2pip_index() {
+        assert_eq!(aa_to_ms2pip_index(AminoAcid::Alanine), Some(0));
+        assert_eq!(aa_to_ms2pip_index(AminoAcid::Leucine), Some(7));
+        assert_eq!(aa_to_ms2pip_index(AminoAcid::Isoleucine), Some(7));
+        assert_eq!(aa_to_ms2pip_index(AminoAcid::Tyrosine), Some(18));
+        assert_eq!(aa_to_ms2pip_index(AminoAcid::Unknown), None);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,44 @@
+use rustyms::prelude::CompoundPeptidoformIon;
+
 /// Compute ln(n!). For typical peptide-length inputs (n < 50) the
 /// iterative sum is fast enough; a lookup table is not warranted.
 pub fn ln_factorial(n: usize) -> f64 {
     (1..=n).map(|k| (k as f64).ln()).sum()
+}
+
+/// Parse an ion string like "b5", "y7", "c3", "z12" into (series, position).
+/// Works on ASCII bytes to avoid heap allocations.
+/// Supports all 6 primary ion series: a, b, c, x, y, z.
+pub fn parse_ion_series_and_index(ion: &str) -> Option<(char, usize)> {
+    let bytes = ion.trim().as_bytes();
+    if bytes.is_empty() {
+        return None;
+    }
+    let series = bytes[0] as char;
+    if !matches!(series, 'a' | 'b' | 'c' | 'x' | 'y' | 'z') {
+        return None;
+    }
+    let digit_end = bytes[1..]
+        .iter()
+        .position(|b| !b.is_ascii_digit())
+        .unwrap_or(bytes.len() - 1);
+    if digit_end == 0 {
+        return None;
+    }
+    let digits = std::str::from_utf8(&bytes[1..1 + digit_end]).ok()?;
+    let idx = digits.parse::<usize>().ok()?;
+    Some((series, idx))
+}
+
+/// Extract the precursor charge from a parsed CompoundPeptidoformIon.
+/// Returns None if no charge carriers are present.
+pub fn extract_charge(compound: &CompoundPeptidoformIon) -> Option<usize> {
+    compound
+        .peptidoforms()
+        .next()
+        .and_then(|pf| pf.get_charge_carriers())
+        .map(|cc| cc.charge().value.unsigned_abs())
+        .filter(|&c| c > 0)
 }
 
 /// Compute the longest run of `true` values in a boolean slice.

--- a/tests/test_ms2pip.py
+++ b/tests/test_ms2pip.py
@@ -57,21 +57,21 @@ class TestMs2pipComputeFeatures:
             )
 
     def test_ion_lengths(self):
-        """Check n_length and c_length per ion."""
+        """Check n_length and c_length per ion (C code: n=i+1, c=peplen-i)."""
         features = ms2pip_compute_features(["ACDEF/2"])
         arr = features[0].reshape(-1, N_FEATURES)
 
-        # Ion 0: n_len=1, c_len=4
+        # Ion 0: n_len=1, c_len=5
         assert arr[0, 27] == 1.0
-        assert arr[0, 28] == 4.0
+        assert arr[0, 28] == 5.0
 
-        # Ion 1: n_len=2, c_len=3
+        # Ion 1: n_len=2, c_len=4
         assert arr[1, 27] == 2.0
-        assert arr[1, 28] == 3.0
+        assert arr[1, 28] == 4.0
 
-        # Ion 3: n_len=4, c_len=1
+        # Ion 3: n_len=4, c_len=2
         assert arr[3, 27] == 4.0
-        assert arr[3, 28] == 1.0
+        assert arr[3, 28] == 2.0
 
     def test_aa_counts(self):
         """AA counts should sum to peptide length for each ion."""

--- a/tests/test_ms2pip.py
+++ b/tests/test_ms2pip.py
@@ -1,0 +1,206 @@
+"""Tests for ms2pip_compute_features and ms2pip_compute_theoretical_mz."""
+
+import numpy as np
+import pytest
+from ms2rescore_rs import ms2pip_compute_features, ms2pip_compute_theoretical_mz
+
+N_FEATURES = 139
+
+
+class TestMs2pipComputeFeatures:
+    """Tests for ms2pip_compute_features."""
+
+    def test_basic_shape(self):
+        """ACDE/2 has 4 AAs -> 3 ions -> flat array of 3*139."""
+        features = ms2pip_compute_features(["ACDE/2"])
+        assert len(features) == 1
+        arr = features[0]
+        assert arr.dtype == np.float32
+        assert arr.shape == (3 * N_FEATURES,)
+
+    def test_reshape(self):
+        """Flat array reshapes to (n_ions, 139)."""
+        features = ms2pip_compute_features(["PEPTIDE/2"])
+        arr = features[0].reshape(-1, N_FEATURES)
+        assert arr.shape == (6, N_FEATURES)  # 7 AAs -> 6 ions
+
+    def test_peptide_level_features(self):
+        """Check shared peptide-level features."""
+        features = ms2pip_compute_features(["ACDE/2"])
+        arr = features[0].reshape(-1, N_FEATURES)
+
+        # p_length, p_charge
+        assert arr[0, 0] == 4.0
+        assert arr[0, 1] == 2.0
+
+        # Charge one-hot: charge=2 -> [0, 1, 0, 0, 0]
+        np.testing.assert_array_equal(arr[0, 2:7], [0, 1, 0, 0, 0])
+
+        # Same shared features for all ions
+        for ion in range(arr.shape[0]):
+            np.testing.assert_array_equal(arr[ion, :27], arr[0, :27])
+
+    def test_charge_onehot(self):
+        """Verify charge one-hot encoding for different charges."""
+        for charge, expected in [
+            (1, [1, 0, 0, 0, 0]),
+            (2, [0, 1, 0, 0, 0]),
+            (3, [0, 0, 1, 0, 0]),
+            (4, [0, 0, 0, 1, 0]),
+            (5, [0, 0, 0, 0, 1]),
+            (6, [0, 0, 0, 0, 1]),  # >= 5
+        ]:
+            features = ms2pip_compute_features([f"ACDE/{charge}"])
+            arr = features[0].reshape(-1, N_FEATURES)
+            np.testing.assert_array_equal(
+                arr[0, 2:7], expected, err_msg=f"Failed for charge={charge}"
+            )
+
+    def test_ion_lengths(self):
+        """Check n_length and c_length per ion."""
+        features = ms2pip_compute_features(["ACDEF/2"])
+        arr = features[0].reshape(-1, N_FEATURES)
+
+        # Ion 0: n_len=1, c_len=4
+        assert arr[0, 27] == 1.0
+        assert arr[0, 28] == 4.0
+
+        # Ion 1: n_len=2, c_len=3
+        assert arr[1, 27] == 2.0
+        assert arr[1, 28] == 3.0
+
+        # Ion 3: n_len=4, c_len=1
+        assert arr[3, 27] == 4.0
+        assert arr[3, 28] == 1.0
+
+    def test_aa_counts(self):
+        """AA counts should sum to peptide length for each ion."""
+        features = ms2pip_compute_features(["ACDE/2"])
+        arr = features[0].reshape(-1, N_FEATURES)
+
+        for ion in range(3):
+            n_counts = arr[ion, 29:67:2]  # n_count for each AA (even indices)
+            c_counts = arr[ion, 30:68:2]  # c_count for each AA (odd indices)
+            assert n_counts.sum() + c_counts.sum() == 4.0  # total = peplen
+
+    def test_batch(self):
+        """Multiple peptides in batch."""
+        features = ms2pip_compute_features(["ACDE/2", "PEPTIDE/3", "AK/1"])
+        assert len(features) == 3
+        assert features[0].shape == (3 * N_FEATURES,)
+        assert features[1].shape == (6 * N_FEATURES,)
+        assert features[2].shape == (1 * N_FEATURES,)
+
+    def test_leucine_isoleucine_equivalence(self):
+        """L should be treated identically to I."""
+        feat_l = ms2pip_compute_features(["ACLDE/2"])
+        feat_i = ms2pip_compute_features(["ACIDE/2"])
+        np.testing.assert_array_equal(feat_l[0], feat_i[0])
+
+    def test_missing_charge_raises(self):
+        """ProForma without charge should raise an error."""
+        with pytest.raises(Exception, match="charge"):
+            ms2pip_compute_features(["ACDE"])
+
+    def test_invalid_proforma_raises(self):
+        """Invalid ProForma should raise an error."""
+        with pytest.raises(Exception):
+            ms2pip_compute_features(["NOT_A_PEPTIDE!!!"])
+
+    def test_features_non_negative(self):
+        """All features should be non-negative (counts, properties are all >= 0)."""
+        features = ms2pip_compute_features(["PEPTIDE/2"])
+        assert np.all(features[0] >= 0)
+
+    def test_modification_handling(self):
+        """Modified peptide should still produce features."""
+        features = ms2pip_compute_features(["AC[Carbamidomethyl]DE/2"])
+        arr = features[0].reshape(-1, N_FEATURES)
+        assert arr.shape == (3, N_FEATURES)
+        # Modified C should be mapped to base AA C for property lookup
+        assert arr[0, 0] == 4.0  # p_length still 4
+
+
+class TestMs2pipComputeTheoreticalMz:
+    """Tests for ms2pip_compute_theoretical_mz."""
+
+    def test_basic_by_ions(self):
+        """ACDE/2 should produce 3 b-ions and 3 y-ions."""
+        result = ms2pip_compute_theoretical_mz(
+            ["ACDE/2"], ["b", "y"], "cidhcd", "monoisotopic"
+        )
+        assert len(result) == 1
+        assert "b" in result[0]
+        assert "y" in result[0]
+        assert len(result[0]["b"]) == 3
+        assert len(result[0]["y"]) == 3
+
+    def test_mz_values_approximate(self):
+        """Compare with ms2pip's known values for ACDE/2 (within tolerance)."""
+        result = ms2pip_compute_theoretical_mz(
+            ["ACDE/2"], ["b", "y"], "cidhcd", "monoisotopic"
+        )
+        # ms2pip C code values: b=[72.04435, 175.05354, 290.08047]
+        # rustyms may differ slightly in precision
+        np.testing.assert_allclose(
+            result[0]["b"], [72.04435, 175.05354, 290.08047], atol=0.001
+        )
+        np.testing.assert_allclose(
+            result[0]["y"], [148.0604, 263.0873, 366.0965], atol=0.001
+        )
+
+    def test_mz_monotonically_increasing(self):
+        """m/z values should increase with ion position."""
+        result = ms2pip_compute_theoretical_mz(
+            ["PEPTIDE/2"], ["b", "y"], "cidhcd", "monoisotopic"
+        )
+        b_mz = result[0]["b"]
+        y_mz = result[0]["y"]
+        # Filter out zeros (unmatched positions)
+        b_nonzero = [v for v in b_mz if v > 0]
+        y_nonzero = [v for v in y_mz if v > 0]
+        assert b_nonzero == sorted(b_nonzero)
+        assert y_nonzero == sorted(y_nonzero)
+
+    def test_batch(self):
+        """Multiple peptides in batch."""
+        result = ms2pip_compute_theoretical_mz(
+            ["ACDE/2", "PEPTIDE/3"], ["b", "y"], "cidhcd", "monoisotopic"
+        )
+        assert len(result) == 2
+        assert len(result[0]["b"]) == 3   # ACDE: 3 ions
+        assert len(result[1]["b"]) == 6   # PEPTIDE: 6 ions
+
+    def test_etd_ion_types(self):
+        """ETD should produce c and z ions."""
+        result = ms2pip_compute_theoretical_mz(
+            ["PEPTIDE/2"], ["c", "z"], "etd", "monoisotopic"
+        )
+        assert "c" in result[0]
+        assert "z" in result[0]
+        # c and z ions should have some non-zero values
+        assert any(v > 0 for v in result[0]["c"])
+        assert any(v > 0 for v in result[0]["z"])
+
+    def test_unrequested_ion_type_absent(self):
+        """Only requested ion types should be in the output."""
+        result = ms2pip_compute_theoretical_mz(
+            ["ACDE/2"], ["b"], "cidhcd", "monoisotopic"
+        )
+        assert "b" in result[0]
+        assert "y" not in result[0]
+
+    def test_no_charge_defaults(self):
+        """Without charge, should still compute m/z (defaults to charge 1)."""
+        result = ms2pip_compute_theoretical_mz(
+            ["ACDE"], ["b", "y"], "cidhcd", "monoisotopic"
+        )
+        assert len(result[0]["b"]) == 3
+        assert all(v > 0 for v in result[0]["b"])
+
+    def test_invalid_proforma_raises(self):
+        """Invalid ProForma should raise."""
+        with pytest.raises(Exception):
+            ms2pip_compute_theoretical_mz(
+                ["NOT_A_PEPTIDE!!!"], ["b", "y"], "cidhcd", "monoisotopic"
+            )


### PR DESCRIPTION
Implements the two remaining C code replacements needed to make ms2pip pure-Python: XGBoost feature vector computation and theoretical fragment m/z calculation. Together with the annotation and scoring functions from the previous PR, this eliminates all dependencies on ms2pip's C/Cython code.

---

### Added

- `ms2pip_compute_features(proformas)` — compute 139 XGBoost features per cleavage site, taking ProForma strings with charge suffix (e.g. `PEPTIDE/2`). Returns flat numpy float32 arrays, reshaped to `(n_ions, 139)` on the Python side. Feature vectors match the original C code exactly for XGBoost model compatibility.
- `ms2pip_compute_theoretical_mz(proformas, ion_types, fragmentation_model, mass_mode)` — compute theoretical fragment m/z using rustyms, consistent with `annotate_ms2_spectra`. Supports all ion types including charge variants (b2, y2).
- Pickle support for `FragmentAnnotation` and `AnnotatedMS2Spectrum`
- Shared helpers in `utils.rs`: `parse_fragment` (direct `FragmentType` enum matching, no heap allocation), `extract_charge`, `aa_to_ms2pip_index`
- Rust unit tests including exact C reference test for ACDE/2
- 20 Python tests for both new functions

### Changed

- Version bumped to `0.5.0-alpha.1`
- Fragment parsing now uses direct enum matching on rustyms `FragmentType` instead of `to_string()` + string parsing, eliminating heap allocations in hot loops
- Amino acid index lookup uses direct `AminoAcid` enum matching instead of `to_string().chars().next()`
- Consolidated `parse_ion_series_and_index` and `extract_fragment_charge` from annotation.rs into shared `parse_fragment` in utils.rs
