### PR TITLE
Fix panic on precursors with empty ions list, bump to 0.5.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "ms2rescore-rs"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "mzdata",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms2rescore-rs"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/io/mzdata.rs
+++ b/src/io/mzdata.rs
@@ -10,21 +10,24 @@ impl From<&mzdata::spectrum::MultiLayerSpectrum> for Precursor {
     fn from(spectrum: &mzdata::spectrum::MultiLayerSpectrum) -> Self {
         let precursor = &spectrum.precursor();
         match precursor {
-            Some(precursor) => Precursor {
-                mz: precursor.ions[0].mz,
-                rt: spectrum
-                    .description
-                    .acquisition
-                    .first_scan()
-                    .map(|s| s.start_time)
-                    .unwrap_or(0.0),
-                im: get_im_from_spectrum_description(spectrum)
-                    .or(get_im_from_selected_ion(spectrum))
-                    .or(get_im_from_first_scan(spectrum))
-                    .unwrap_or(0.0),
-                charge: get_charge_from_spectrum(spectrum).unwrap_or(0),
-                intensity: precursor.ions[0].intensity as f64,
-            },
+            Some(precursor) => {
+                let first_ion = precursor.ions.first();
+                Precursor {
+                    mz: first_ion.map(|i| i.mz).unwrap_or(0.0),
+                    rt: spectrum
+                        .description
+                        .acquisition
+                        .first_scan()
+                        .map(|s| s.start_time)
+                        .unwrap_or(0.0),
+                    im: get_im_from_spectrum_description(spectrum)
+                        .or(get_im_from_selected_ion(spectrum))
+                        .or(get_im_from_first_scan(spectrum))
+                        .unwrap_or(0.0),
+                    charge: get_charge_from_spectrum(spectrum).unwrap_or(0),
+                    intensity: first_ion.map(|i| i.intensity as f64).unwrap_or(0.0),
+                }
+            }
             None => Precursor::default(),
         }
     }


### PR DESCRIPTION
Handle spectra where the precursor exists but has no selected ions (e.g. missing PEPMASS in MGF, incomplete mzML). Default to mz=0.0 and intensity=0.0, consistent with missing precursor handling.