### PR TITLE
Speed up annotation and theoretical m/z calculation for MS²PIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "ms2rescore-rs"
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 dependencies = [
  "mzdata",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms2rescore-rs"
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -133,31 +133,41 @@ pub fn annotate_ms2_spectra(
     // Precompute theoretical fragments and parsed peptides per unique peptide+charge
     type CacheEntry = (CompoundPeptidoformIon, Vec<rustyms::fragment::Fragment>);
 
-    let mut frag_cache: HashMap<(String, i32), Arc<Option<CacheEntry>>> = HashMap::new();
-    for item in &owned {
-        let key = (item.proforma.clone(), item.precursor_charge);
-        if item.precursor_charge <= 0 || frag_cache.contains_key(&key) {
-            continue;
+    let unique_keys: Vec<(String, i32)> = {
+        let mut seen = HashMap::new();
+        for item in &owned {
+            if item.precursor_charge > 0 {
+                seen.entry((item.proforma.clone(), item.precursor_charge))
+                    .or_insert(());
+            }
         }
+        seen.into_keys().collect()
+    };
 
-        let entry = CompoundPeptidoformIon::pro_forma(&item.proforma, None)
-            .ok()
-            .map(|peptide| {
-                let frag_charge = rustyms::system::isize::Charge::new::<rustyms::system::e>(
-                    item.precursor_charge as isize,
-                );
-                let frags = peptide.generate_theoretical_fragments(frag_charge, &model);
-                (peptide, frags)
-            });
-
-        frag_cache.insert(key, Arc::new(entry));
-    }
-
-    let frag_cache = Arc::new(frag_cache);
     let params = Arc::new(params);
 
-    // Release GIL and parallelize
+    // Release GIL and parallelize both cache building and annotation
     let results: Result<Vec<AnnotatedMS2Spectrum>, String> = py.detach(|| {
+        let frag_cache: Arc<HashMap<(String, i32), Arc<Option<CacheEntry>>>> = Arc::new(
+            unique_keys
+                .into_par_iter()
+                .map(|(proforma, charge)| {
+                    let entry = CompoundPeptidoformIon::pro_forma(&proforma, None)
+                        .ok()
+                        .map(|peptide| {
+                            let frag_charge =
+                                rustyms::system::isize::Charge::new::<rustyms::system::e>(
+                                    charge as isize,
+                                );
+                            let frags =
+                                peptide.generate_theoretical_fragments(frag_charge, &model);
+                            (peptide, frags)
+                        });
+                    ((proforma, charge), Arc::new(entry))
+                })
+                .collect(),
+        );
+
         owned
             .into_par_iter()
             .map(|item| {

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -81,7 +81,6 @@ pub fn annotate_ms2_spectra(
         mz_f32: Vec<f32>,
         intensity_f32: Vec<f32>,
         precursor: Option<crate::types::precursor::Precursor>,
-        seq_len: usize,
         precursor_charge: i32,
         proforma: String,
     }
@@ -110,17 +109,11 @@ pub fn annotate_ms2_spectra(
             .unwrap_or(&proformas[i])
             .to_string();
 
-        let seq_len = CompoundPeptidoformIon::pro_forma(&proforma, None)
-            .ok()
-            .and_then(|cpf| cpf.peptidoforms().next().map(|pf| pf.sequence().len()))
-            .unwrap_or(0);
-
         owned.push(OwnedSpec {
             id: spec.identifier.clone(),
             mz_f32: spec.mz.clone(),
             intensity_f32: spec.intensity.clone(),
             precursor: spec.precursor.clone(),
-            seq_len,
             precursor_charge: spec
                 .precursor
                 .as_ref()
@@ -136,7 +129,11 @@ pub fn annotate_ms2_spectra(
     let params = rustyms::annotation::model::MatchingParameters::default().tolerance(tolerance);
 
     // Precompute theoretical fragments and parsed peptides per unique peptide+charge
-    type CacheEntry = (CompoundPeptidoformIon, Vec<rustyms::fragment::Fragment>);
+    struct CacheEntry {
+        peptide: CompoundPeptidoformIon,
+        fragments: Vec<rustyms::fragment::Fragment>,
+        seq_len: usize,
+    }
 
     let unique_keys: Vec<(String, i32)> = {
         let mut seen = HashMap::new();
@@ -160,13 +157,22 @@ pub fn annotate_ms2_spectra(
                     let entry = CompoundPeptidoformIon::pro_forma(&proforma, None)
                         .ok()
                         .map(|peptide| {
+                            let seq_len = peptide
+                                .peptidoforms()
+                                .next()
+                                .map(|pf| pf.sequence().len())
+                                .unwrap_or(0);
                             let frag_charge =
                                 rustyms::system::isize::Charge::new::<rustyms::system::e>(
                                     charge as isize,
                                 );
-                            let frags =
+                            let fragments =
                                 peptide.generate_theoretical_fragments(frag_charge, &model);
-                            (peptide, frags)
+                            CacheEntry {
+                                peptide,
+                                fragments,
+                                seq_len,
+                            }
                         });
                     ((proforma, charge), Arc::new(entry))
                 })
@@ -183,15 +189,15 @@ pub fn annotate_ms2_spectra(
                     ));
                 }
 
-                if item.mz_f32.is_empty() || item.seq_len == 0 || item.precursor_charge <= 0 {
+                if item.mz_f32.is_empty() || item.precursor_charge <= 0 {
                     return Ok(item.empty_annotated());
                 }
 
                 let key = (item.proforma.clone(), item.precursor_charge);
                 let cache_entry = frag_cache.get(&key).and_then(|e| e.as_ref().as_ref());
 
-                let (peptide, frags) = match cache_entry {
-                    Some((p, f)) if !f.is_empty() => (p, f),
+                let entry = match cache_entry {
+                    Some(e) if e.seq_len > 0 && !e.fragments.is_empty() => e,
                     _ => return Ok(item.empty_annotated()),
                 };
 
@@ -212,7 +218,8 @@ pub fn annotate_ms2_spectra(
 
                 spectrum.extend(peaks);
 
-                let annotated = spectrum.annotate(peptide.clone(), frags.as_slice(), &params, mode);
+                let annotated =
+                    spectrum.annotate(entry.peptide.clone(), &entry.fragments, &params, mode);
 
                 let peak_annotations: Vec<Vec<FragmentAnnotation>> = annotated
                     .spectrum()

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -7,14 +7,11 @@ use rayon::prelude::*;
 
 use crate::types::annotation::{AnnotatedMS2Spectrum, FragmentAnnotation};
 use crate::types::ms2_spectrum::MS2Spectrum;
-use crate::utils::parse_fragment;
+use crate::utils::{build_theoretical_fragments, search_sorted_mz};
 
-use ordered_float::OrderedFloat;
 use rustyms::annotation::model::FragmentationModel;
-use rustyms::annotation::AnnotatableSpectrum;
 use rustyms::chemistry::MassMode;
 use rustyms::prelude::CompoundPeptidoformIon;
-use rustyms::spectrum::{PeakSpectrum, RawPeak, RawSpectrum};
 use rustyms::system::f64::MassOverCharge;
 use rustyms::system::mass_over_charge::thomson;
 
@@ -126,14 +123,12 @@ pub fn annotate_ms2_spectra(
     let model = parse_fragmentation_model(&fragmentation_model)?;
     let mode = parse_mass_mode(&mass_mode)?;
     let tolerance = parse_tolerance(tolerance_value, &tolerance_mode)?;
-    let params = rustyms::annotation::model::MatchingParameters::default().tolerance(tolerance);
-
-    // Precompute theoretical fragments and parsed peptides per unique peptide+charge
+    // Precompute theoretical fragments per unique peptidoform+charge
     struct CacheEntry {
-        peptide: CompoundPeptidoformIon,
-        fragments: Vec<rustyms::fragment::Fragment>,
+        fragments: Vec<crate::utils::CachedFragment>,
         seq_len: usize,
     }
+    type FragCache = Arc<HashMap<(String, i32), Arc<Option<CacheEntry>>>>;
 
     let unique_keys: Vec<(String, i32)> = {
         let mut seen = HashMap::new();
@@ -146,18 +141,16 @@ pub fn annotate_ms2_spectra(
         seen.into_keys().collect()
     };
 
-    let params = Arc::new(params);
-
     // Release GIL and parallelize both cache building and annotation
     let results: Result<Vec<AnnotatedMS2Spectrum>, String> = py.detach(|| {
-        let frag_cache: Arc<HashMap<(String, i32), Arc<Option<CacheEntry>>>> = Arc::new(
+        let frag_cache: FragCache = Arc::new(
             unique_keys
                 .into_par_iter()
                 .map(|(proforma, charge)| {
                     let entry = CompoundPeptidoformIon::pro_forma(&proforma, None)
                         .ok()
-                        .map(|peptide| {
-                            let seq_len = peptide
+                        .map(|peptidoform| {
+                            let seq_len = peptidoform
                                 .peptidoforms()
                                 .next()
                                 .map(|pf| pf.sequence().len())
@@ -167,9 +160,8 @@ pub fn annotate_ms2_spectra(
                                     charge as isize,
                                 );
                             let fragments =
-                                peptide.generate_theoretical_fragments(frag_charge, &model);
+                                build_theoretical_fragments(&peptidoform, frag_charge, &model, mode);
                             CacheEntry {
-                                peptide,
                                 fragments,
                                 seq_len,
                             }
@@ -201,42 +193,24 @@ pub fn annotate_ms2_spectra(
                     _ => return Ok(item.empty_annotated()),
                 };
 
-                // Build RawSpectrum from f32 data (convert to f64 in-place, no pre-stored copy)
-                let mut spectrum = RawSpectrum::default();
-                spectrum.title = item.id.clone();
-                spectrum.num_scans = 1;
+                let mz_range = MassOverCharge::new::<thomson>(0.0)
+                    ..=MassOverCharge::new::<thomson>(f64::MAX);
+                let mut peak_annotations = vec![Vec::new(); item.mz_f32.len()];
 
-                let peaks: Vec<RawPeak> = item
-                    .mz_f32
-                    .iter()
-                    .zip(item.intensity_f32.iter())
-                    .map(|(&mz, &inten)| RawPeak {
-                        mz: MassOverCharge::new::<thomson>(mz as f64),
-                        intensity: OrderedFloat(inten as f64),
-                    })
-                    .collect();
+                for frag in &entry.fragments {
+                    let fragment_mz = MassOverCharge::new::<thomson>(frag.mz);
+                    if !mz_range.contains(&fragment_mz) {
+                        continue;
+                    }
 
-                spectrum.extend(peaks);
-
-                let annotated =
-                    spectrum.annotate(entry.peptide.clone(), &entry.fragments, &params, mode);
-
-                let peak_annotations: Vec<Vec<FragmentAnnotation>> = annotated
-                    .spectrum()
-                    .map(|peak| {
-                        peak.annotation
-                            .iter()
-                            .filter_map(|frag| {
-                                let (series, position, charge) = parse_fragment(frag)?;
-                                Some(FragmentAnnotation {
-                                    series: series.to_string(),
-                                    position,
-                                    charge,
-                                })
-                            })
-                            .collect()
-                    })
-                    .collect();
+                    if let Some(idx) = search_sorted_mz(&item.mz_f32, frag.mz, &tolerance) {
+                        peak_annotations[idx].push(FragmentAnnotation {
+                            series: frag.series.to_string(),
+                            position: frag.position,
+                            charge: frag.charge,
+                        });
+                    }
+                }
 
                 Ok(AnnotatedMS2Spectrum {
                     identifier: item.id,

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -58,21 +58,19 @@ fn parse_tolerance(
 
 /// Annotate MS2 spectra with theoretical fragment ions.
 #[pyfunction]
-#[allow(clippy::too_many_arguments)]
 pub fn annotate_ms2_spectra(
     py: Python<'_>,
     spectra: Vec<Py<MS2Spectrum>>,
     proformas: Vec<String>,
-    seq_lens: Vec<usize>,
     fragmentation_model: String,
     mass_mode: String,
     tolerance_value: f64,
     tolerance_mode: String,
 ) -> PyResult<Vec<AnnotatedMS2Spectrum>> {
     let n = spectra.len();
-    if proformas.len() != n || seq_lens.len() != n {
+    if proformas.len() != n {
         return Err(PyException::new_err(
-            "Input arrays must have identical length: spectra, proformas, seq_lens",
+            "Input arrays must have identical length: spectra, proformas",
         ));
     }
 
@@ -106,22 +104,29 @@ pub fn annotate_ms2_spectra(
         let spec_ref = spectra[i].bind(py);
         let spec = spec_ref.borrow();
 
+        let proforma = proformas[i]
+            .split('/')
+            .next()
+            .unwrap_or(&proformas[i])
+            .to_string();
+
+        let seq_len = CompoundPeptidoformIon::pro_forma(&proforma, None)
+            .ok()
+            .and_then(|cpf| cpf.peptidoforms().next().map(|pf| pf.sequence().len()))
+            .unwrap_or(0);
+
         owned.push(OwnedSpec {
             id: spec.identifier.clone(),
             mz_f32: spec.mz.clone(),
             intensity_f32: spec.intensity.clone(),
             precursor: spec.precursor.clone(),
-            seq_len: seq_lens[i],
+            seq_len,
             precursor_charge: spec
                 .precursor
                 .as_ref()
                 .map(|p| p.charge as i32)
                 .unwrap_or(0),
-            proforma: proformas[i]
-                .split('/')
-                .next()
-                .unwrap_or(&proformas[i])
-                .to_string(),
+            proforma,
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,5 +35,9 @@ fn ms2rescore_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
         ms2pip::theoretical_mz::ms2pip_compute_theoretical_mz,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(
+        ms2pip::targets::ms2pip_extract_targets,
+        m
+    )?)?;
     Ok(())
 }

--- a/src/ms2pip/feature_vectors.rs
+++ b/src/ms2pip/feature_vectors.rs
@@ -48,14 +48,14 @@ fn quartiles_with_denom(sorted: &[u32], denom: usize) -> [u32; 5] {
 /// Extract amino acid indices and charge from a ProForma string.
 /// Returns (aa_indices, charge). Modified residues are mapped to their base AA.
 fn parse_proforma(proforma: &str) -> Result<(Vec<usize>, usize), String> {
-    let compound = CompoundPeptidoformIon::pro_forma(proforma, None)
+    let peptidoform = CompoundPeptidoformIon::pro_forma(proforma, None)
         .map_err(|e| format!("Failed to parse ProForma '{proforma}': {e}"))?;
 
-    let charge = extract_charge(&compound)
+    let charge = extract_charge(&peptidoform)
         .ok_or_else(|| format!("No charge state found in '{proforma}'. MS2PIP requires a charge (e.g. 'PEPTIDE/2')."))?;
 
     // Extract amino acid sequence — must be exactly one peptidoform
-    let peptidoform_ions = compound.peptidoform_ions();
+    let peptidoform_ions = peptidoform.peptidoform_ions();
     if peptidoform_ions.len() != 1 {
         return Err(format!(
             "Expected exactly 1 peptidoform ion in '{proforma}', found {}",
@@ -64,8 +64,8 @@ fn parse_proforma(proforma: &str) -> Result<(Vec<usize>, usize), String> {
     }
 
     let mut aa_indices = Vec::new();
-    for peptidoform in compound.peptidoforms() {
-        for pos in peptidoform.sequence() {
+    for peptide in peptidoform.peptidoforms() {
+        for pos in peptide.sequence() {
             let aa = pos.aminoacid.aminoacid();
             let idx = aa_to_ms2pip_index(aa).ok_or_else(|| {
                 format!("Unsupported amino acid '{aa}' in '{proforma}'")

--- a/src/ms2pip/mod.rs
+++ b/src/ms2pip/mod.rs
@@ -1,2 +1,3 @@
 pub mod feature_vectors;
+pub mod targets;
 pub mod theoretical_mz;

--- a/src/ms2pip/targets.rs
+++ b/src/ms2pip/targets.rs
@@ -1,0 +1,123 @@
+use std::collections::HashMap;
+
+use numpy::{PyArray1, PyArrayMethods};
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+use rayon::prelude::*;
+
+use crate::types::annotation::AnnotatedMS2Spectrum;
+
+/// Floor value for unmatched ions: log2(0.001)
+const LOG2_FLOOR: f32 = -9.965_784;
+
+/// Extract per-ion-type observed intensity arrays from annotated spectra.
+///
+/// For each spectrum, maps peak annotations + observed intensities onto
+/// per-ion-type arrays of length `seq_len - 1`, taking the max intensity
+/// when multiple peaks match the same theoretical ion position.
+///
+/// Sequence length is derived from the max annotation position in each spectrum.
+/// Unmatched positions are filled with `log2(0.001)`.
+#[pyfunction]
+pub fn ms2pip_extract_targets(
+    py: Python<'_>,
+    annotated_spectra: Vec<Py<AnnotatedMS2Spectrum>>,
+    intensities: Vec<Py<PyArray1<f32>>>,
+    ion_types: Vec<String>,
+) -> PyResult<Vec<HashMap<String, Py<PyArray1<f32>>>>> {
+    let n = annotated_spectra.len();
+    if intensities.len() != n {
+        return Err(PyException::new_err(
+            "Input arrays must have identical length: annotated_spectra, intensities",
+        ));
+    }
+
+    // Extract owned data under the GIL
+    struct OwnedData {
+        peak_annotations: Vec<Vec<(String, usize)>>, // (ion_key, 0-indexed position)
+        intensities: Vec<f32>,
+        n_ions: usize,
+    }
+
+    let mut owned: Vec<OwnedData> = Vec::with_capacity(n);
+    for i in 0..n {
+        let spec_ref = annotated_spectra[i].bind(py);
+        let spec = spec_ref.borrow();
+
+        let intensities_arr = intensities[i].bind(py);
+        let intensities_vec = unsafe { intensities_arr.as_slice()? }.to_vec();
+
+        // Derive n_ions (seq_len - 1) from max annotation position
+        let mut max_pos: usize = 0;
+        let peak_annotations: Vec<Vec<(String, usize)>> = spec
+            .peak_annotations
+            .iter()
+            .map(|annotations| {
+                annotations
+                    .iter()
+                    .filter_map(|ann| {
+                        if ann.position < 1 {
+                            return None;
+                        }
+                        let ion_key = if ann.charge <= 1 {
+                            ann.series.clone()
+                        } else {
+                            format!("{}{}", ann.series, ann.charge)
+                        };
+                        if !ion_types.contains(&ion_key) {
+                            return None;
+                        }
+                        let idx = ann.position - 1;
+                        if ann.position > max_pos {
+                            max_pos = ann.position;
+                        }
+                        Some((ion_key, idx))
+                    })
+                    .collect()
+            })
+            .collect();
+
+        owned.push(OwnedData {
+            peak_annotations,
+            intensities: intensities_vec,
+            n_ions: max_pos,
+        });
+    }
+
+    // Release GIL and process in parallel
+    let results: Vec<HashMap<String, Vec<f32>>> = py.detach(|| {
+        owned
+            .into_par_iter()
+            .map(|data| {
+                let mut target_map: HashMap<String, Vec<f32>> = ion_types
+                    .iter()
+                    .map(|it| (it.clone(), vec![LOG2_FLOOR; data.n_ions]))
+                    .collect();
+
+                for (peak_idx, annotations) in data.peak_annotations.iter().enumerate() {
+                    let intensity = data.intensities.get(peak_idx).copied().unwrap_or(0.0);
+                    for (ion_key, idx) in annotations {
+                        if let Some(arr) = target_map.get_mut(ion_key) {
+                            if *idx < arr.len() {
+                                arr[*idx] = arr[*idx].max(intensity);
+                            }
+                        }
+                    }
+                }
+
+                target_map
+            })
+            .collect()
+    });
+
+    // Convert to numpy arrays
+    Ok(results
+        .into_iter()
+        .map(|target_map| {
+            target_map
+                .into_iter()
+                .map(|(key, vals)| (key, PyArray1::from_vec(py, vals).into()))
+                .collect()
+        })
+        .collect())
+}

--- a/src/ms2pip/targets.rs
+++ b/src/ms2pip/targets.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use numpy::{PyArray1, PyArrayMethods};
 use pyo3::exceptions::PyException;
@@ -16,7 +16,6 @@ const LOG2_FLOOR: f32 = -9.965_784;
 /// per-ion-type arrays of length `seq_len - 1`, taking the max intensity
 /// when multiple peaks match the same theoretical ion position.
 ///
-/// Sequence length is derived from the max annotation position in each spectrum.
 /// Unmatched positions are filled with `log2(0.001)`.
 #[pyfunction]
 pub fn ms2pip_extract_targets(
@@ -24,13 +23,16 @@ pub fn ms2pip_extract_targets(
     annotated_spectra: Vec<Py<AnnotatedMS2Spectrum>>,
     intensities: Vec<Py<PyArray1<f32>>>,
     ion_types: Vec<String>,
+    seq_lens: Vec<usize>,
 ) -> PyResult<Vec<HashMap<String, Py<PyArray1<f32>>>>> {
     let n = annotated_spectra.len();
-    if intensities.len() != n {
+    if intensities.len() != n || seq_lens.len() != n {
         return Err(PyException::new_err(
-            "Input arrays must have identical length: annotated_spectra, intensities",
+            "Input arrays must have identical length: annotated_spectra, intensities, seq_lens",
         ));
     }
+
+    let ion_types_set: HashSet<&str> = ion_types.iter().map(|s| s.as_str()).collect();
 
     // Extract owned data under the GIL
     struct OwnedData {
@@ -47,8 +49,7 @@ pub fn ms2pip_extract_targets(
         let intensities_arr = intensities[i].bind(py);
         let intensities_vec = unsafe { intensities_arr.as_slice()? }.to_vec();
 
-        // Derive n_ions (seq_len - 1) from max annotation position
-        let mut max_pos: usize = 0;
+        let n_ions = seq_lens[i].saturating_sub(1);
         let peak_annotations: Vec<Vec<(String, usize)>> = spec
             .peak_annotations
             .iter()
@@ -64,12 +65,12 @@ pub fn ms2pip_extract_targets(
                         } else {
                             format!("{}{}", ann.series, ann.charge)
                         };
-                        if !ion_types.contains(&ion_key) {
+                        if !ion_types_set.contains(ion_key.as_str()) {
                             return None;
                         }
                         let idx = ann.position - 1;
-                        if ann.position > max_pos {
-                            max_pos = ann.position;
+                        if idx >= n_ions {
+                            return None;
                         }
                         Some((ion_key, idx))
                     })
@@ -80,7 +81,7 @@ pub fn ms2pip_extract_targets(
         owned.push(OwnedData {
             peak_annotations,
             intensities: intensities_vec,
-            n_ions: max_pos,
+            n_ions,
         });
     }
 
@@ -98,9 +99,7 @@ pub fn ms2pip_extract_targets(
                     let intensity = data.intensities.get(peak_idx).copied().unwrap_or(0.0);
                     for (ion_key, idx) in annotations {
                         if let Some(arr) = target_map.get_mut(ion_key) {
-                            if *idx < arr.len() {
-                                arr[*idx] = arr[*idx].max(intensity);
-                            }
+                            arr[*idx] = arr[*idx].max(intensity);
                         }
                     }
                 }

--- a/src/ms2pip/theoretical_mz.rs
+++ b/src/ms2pip/theoretical_mz.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use numpy::PyArray1;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -21,7 +22,7 @@ pub fn ms2pip_compute_theoretical_mz(
     ion_types: Vec<String>,
     fragmentation_model: String,
     mass_mode: String,
-) -> PyResult<Vec<HashMap<String, Vec<f64>>>> {
+) -> PyResult<Vec<HashMap<String, Py<PyArray1<f32>>>>> {
     let model = parse_fragmentation_model(&fragmentation_model)?;
     let mode = parse_mass_mode(&mass_mode)?;
 
@@ -89,5 +90,17 @@ pub fn ms2pip_compute_theoretical_mz(
             .collect()
     });
 
-    results.map_err(PyValueError::new_err)
+    let results = results.map_err(PyValueError::new_err)?;
+    Ok(results
+        .into_iter()
+        .map(|mz_map| {
+            mz_map
+                .into_iter()
+                .map(|(key, vals)| {
+                    let f32_vals: Vec<f32> = vals.into_iter().map(|v| v as f32).collect();
+                    (key, PyArray1::from_vec(py, f32_vals).into())
+                })
+                .collect()
+        })
+        .collect())
 }

--- a/src/ms2pip/theoretical_mz.rs
+++ b/src/ms2pip/theoretical_mz.rs
@@ -13,8 +13,8 @@ use crate::utils::{extract_charge, parse_fragment};
 /// Compute theoretical m/z values for fragment ions.
 ///
 /// Uses rustyms fragment generation, consistent with `annotate_ms2_spectra`.
-/// Returns a dict mapping ion type (e.g. "b", "y", "b2") to a list of m/z
-/// values ordered by ion position, length = seq_len - 1.
+/// Returns a dict mapping ion type (e.g. "b", "y", "b2") to a numpy float32
+/// array of m/z values ordered by ion position, length = seq_len - 1.
 #[pyfunction]
 pub fn ms2pip_compute_theoretical_mz(
     py: Python<'_>,

--- a/src/ms2pip/theoretical_mz.rs
+++ b/src/ms2pip/theoretical_mz.rs
@@ -8,7 +8,35 @@ use rayon::prelude::*;
 use rustyms::prelude::CompoundPeptidoformIon;
 
 use crate::annotation::{parse_fragmentation_model, parse_mass_mode};
-use crate::utils::{extract_charge, parse_fragment};
+use crate::utils::{build_theoretical_fragments, extract_charge};
+
+#[derive(Clone)]
+struct IonTypeSpec {
+    key: String,
+    series: char,
+    charge: usize,
+}
+
+fn parse_ion_type_spec(ion_type: &str) -> Option<IonTypeSpec> {
+    let mut chars = ion_type.chars();
+    let series = chars.next()?;
+    if !matches!(series, 'a' | 'b' | 'c' | 'x' | 'y' | 'z') {
+        return None;
+    }
+
+    let suffix: String = chars.collect();
+    let charge = if suffix.is_empty() {
+        1
+    } else {
+        suffix.parse().ok()?
+    };
+
+    Some(IonTypeSpec {
+        key: ion_type.to_string(),
+        series,
+        charge,
+    })
+}
 
 /// Compute theoretical m/z values for fragment ions.
 ///
@@ -25,67 +53,63 @@ pub fn ms2pip_compute_theoretical_mz(
 ) -> PyResult<Vec<HashMap<String, Py<PyArray1<f32>>>>> {
     let model = parse_fragmentation_model(&fragmentation_model)?;
     let mode = parse_mass_mode(&mass_mode)?;
+    let ion_specs: Vec<IonTypeSpec> = ion_types
+        .iter()
+        .map(|ion_type| {
+            parse_ion_type_spec(ion_type).ok_or_else(|| {
+                PyValueError::new_err(format!("Unsupported ion type: {ion_type}"))
+            })
+        })
+        .collect::<PyResult<_>>()?;
 
-    let results: Result<Vec<HashMap<String, Vec<f64>>>, String> = py.detach(|| {
+    let ion_index: HashMap<(char, usize), usize> = ion_specs
+        .iter()
+        .enumerate()
+        .map(|(idx, spec)| ((spec.series, spec.charge), idx))
+        .collect();
+
+    let results: Result<Vec<Vec<Vec<f32>>>, String> = py.detach(|| {
         proformas
             .par_iter()
             .enumerate()
             .map(|(i, pf)| {
-                let compound = CompoundPeptidoformIon::pro_forma(pf, None)
+                let peptidoform = CompoundPeptidoformIon::pro_forma(pf, None)
                     .map_err(|e| format!("ProForma at index {i}: {e}"))?;
 
-                let charge = extract_charge(&compound).unwrap_or(1) as isize;
+                let charge = extract_charge(&peptidoform).unwrap_or(1) as isize;
 
-                let seq_len = compound
+                let seq_len = peptidoform
                     .peptidoforms()
                     .next()
                     .map(|pf| pf.sequence().len())
                     .unwrap_or(0);
 
                 if seq_len < 2 {
-                    return Ok(ion_types
-                        .iter()
-                        .map(|it| (it.clone(), Vec::new()))
-                        .collect());
+                    return Ok(vec![Vec::new(); ion_specs.len()]);
                 }
 
                 let n_ions = seq_len - 1;
                 let frag_charge =
                     rustyms::system::isize::Charge::new::<rustyms::system::e>(charge);
-                let frags = compound.generate_theoretical_fragments(frag_charge, &model);
+                let fragments =
+                    build_theoretical_fragments(&peptidoform, frag_charge, &model, mode);
 
-                let mut mz_map: HashMap<String, Vec<f64>> = ion_types
-                    .iter()
-                    .map(|it| (it.clone(), vec![0.0; n_ions]))
-                    .collect();
+                let mut mz_arrays = vec![vec![0.0_f32; n_ions]; ion_specs.len()];
 
-                for frag in &frags {
-                    let (series, position, frag_charge) = match parse_fragment(frag) {
-                        Some(info) => info,
-                        None => continue,
-                    };
-
-                    if position < 1 || position > n_ions {
+                for frag in &fragments {
+                    if frag.position < 1 || frag.position > n_ions {
                         continue;
                     }
 
-                    let ion_key = if frag_charge <= 1 {
-                        series.to_string()
-                    } else {
-                        format!("{series}{frag_charge}")
-                    };
-
-                    if let Some(arr) = mz_map.get_mut(&ion_key) {
-                        let idx = position - 1;
-                        if let Some(mz) = frag.mz(mode) {
-                            if arr[idx] == 0.0 {
-                                arr[idx] = mz.value;
-                            }
+                    if let Some(&array_idx) = ion_index.get(&(frag.series, frag.charge)) {
+                        let pos_idx = frag.position - 1;
+                        if mz_arrays[array_idx][pos_idx] == 0.0 {
+                            mz_arrays[array_idx][pos_idx] = frag.mz as f32;
                         }
                     }
                 }
 
-                Ok(mz_map)
+                Ok(mz_arrays)
             })
             .collect()
     });
@@ -93,12 +117,13 @@ pub fn ms2pip_compute_theoretical_mz(
     let results = results.map_err(PyValueError::new_err)?;
     Ok(results
         .into_iter()
-        .map(|mz_map| {
-            mz_map
-                .into_iter()
-                .map(|(key, vals)| {
-                    let f32_vals: Vec<f32> = vals.into_iter().map(|v| v as f32).collect();
-                    (key, PyArray1::from_vec(py, f32_vals).into())
+        .map(|mz_arrays| {
+            ion_specs
+                .iter()
+                .cloned()
+                .zip(mz_arrays)
+                .map(|(spec, vals)| {
+                    (spec.key, PyArray1::from_vec(py, vals).into())
                 })
                 .collect()
         })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,20 @@
+use rustyms::annotation::model::FragmentationModel;
+use rustyms::chemistry::MassMode;
 use rustyms::fragment::{Fragment, FragmentType};
 use rustyms::prelude::CompoundPeptidoformIon;
+use rustyms::quantities::{Tolerance, WithinTolerance};
 use rustyms::sequence::AminoAcid;
+use rustyms::system::f64::MassOverCharge;
+use rustyms::system::isize::Charge;
+use rustyms::system::mass_over_charge::thomson;
+
+#[derive(Clone, Copy, Debug)]
+pub struct CachedFragment {
+    pub series: char,
+    pub position: usize,
+    pub charge: usize,
+    pub mz: f64,
+}
 
 /// Compute ln(n!). For typical peptide-length inputs (n < 50) the
 /// iterative sum is fast enough; a lookup table is not warranted.
@@ -25,15 +39,69 @@ pub fn parse_fragment(frag: &Fragment) -> Option<(char, usize, usize)> {
     Some((series, pos.series_number, charge))
 }
 
-/// Extract the precursor charge from a parsed CompoundPeptidoformIon.
+/// Extract the precursor charge from a parsed peptidoform.
 /// Returns None if no charge carriers are present.
-pub fn extract_charge(compound: &CompoundPeptidoformIon) -> Option<usize> {
-    compound
+pub fn extract_charge(peptidoform: &CompoundPeptidoformIon) -> Option<usize> {
+    peptidoform
         .peptidoforms()
         .next()
         .and_then(|pf| pf.get_charge_carriers())
         .map(|cc| cc.charge().value.unsigned_abs())
         .filter(|&c| c > 0)
+}
+
+pub fn build_theoretical_fragments(
+    peptidoform: &CompoundPeptidoformIon,
+    max_charge: Charge,
+    model: &FragmentationModel,
+    mode: MassMode,
+) -> Vec<CachedFragment> {
+    peptidoform
+        .generate_theoretical_fragments(max_charge, model)
+        .into_iter()
+        .filter_map(|frag| {
+            let (series, position, charge) = parse_fragment(&frag)?;
+            let mz = frag.mz(mode)?.value;
+            Some(CachedFragment {
+                series,
+                position,
+                charge,
+                mz,
+            })
+        })
+        .collect()
+}
+
+pub fn search_sorted_mz(
+    mz_values: &[f32],
+    query_mz: f64,
+    tolerance: &Tolerance<MassOverCharge>,
+) -> Option<usize> {
+    if mz_values.is_empty() {
+        return None;
+    }
+
+    let index = mz_values
+        .binary_search_by(|mz| (*mz as f64).total_cmp(&query_mz))
+        .unwrap_or_else(|i| i);
+
+    let start = index.saturating_sub(1);
+    let end = (index + 1).min(mz_values.len() - 1);
+    let query = MassOverCharge::new::<thomson>(query_mz);
+
+    let mut closest: Option<(usize, MassOverCharge)> = None;
+    let mut closest_ppm = f64::INFINITY;
+
+    for (i, mz) in mz_values.iter().enumerate().take(end + 1).skip(start) {
+        let observed = MassOverCharge::new::<thomson>(*mz as f64);
+        let ppm = observed.ppm(query).value;
+        if ppm < closest_ppm {
+            closest_ppm = ppm;
+            closest = Some((i, observed));
+        }
+    }
+
+    closest.and_then(|(index, observed)| tolerance.within(&observed, &query).then_some(index))
 }
 
 /// Map a rustyms AminoAcid to its ms2pip index (0..18).
@@ -105,5 +173,21 @@ mod tests {
         assert_eq!(aa_to_ms2pip_index(AminoAcid::Isoleucine), Some(7));
         assert_eq!(aa_to_ms2pip_index(AminoAcid::Tyrosine), Some(18));
         assert_eq!(aa_to_ms2pip_index(AminoAcid::Unknown), None);
+    }
+
+    #[test]
+    fn test_search_sorted_mz_absolute() {
+        let mz = [100.0_f32, 200.0, 300.0];
+        let tol = Tolerance::new_absolute(MassOverCharge::new::<thomson>(0.02));
+        assert_eq!(search_sorted_mz(&mz, 200.01, &tol), Some(1));
+        assert_eq!(search_sorted_mz(&mz, 200.05, &tol), None);
+    }
+
+    #[test]
+    fn test_search_sorted_mz_ppm() {
+        let mz = [100.0_f32, 200.0, 300.0];
+        let tol = Tolerance::new_ppm(10.0);
+        assert_eq!(search_sorted_mz(&mz, 200.001, &tol), Some(1));
+        assert_eq!(search_sorted_mz(&mz, 200.01, &tol), None);
     }
 }

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -46,7 +46,6 @@ class TestAnnotateMS2Spectra:
         results = annotate_ms2_spectra(
             spectra=[spectrum],
             proformas=[PEPTIDE_PROFORMA],
-            seq_lens=[PEPTIDE_SEQ_LEN],
             fragmentation_model="cidhcd",
             mass_mode="monoisotopic",
             tolerance_value=20.0,
@@ -78,7 +77,6 @@ class TestAnnotateMS2Spectra:
         results = annotate_ms2_spectra(
             spectra=[spectrum],
             proformas=[PEPTIDE_PROFORMA],
-            seq_lens=[PEPTIDE_SEQ_LEN],
             fragmentation_model="cidhcd",
             mass_mode="monoisotopic",
             tolerance_value=20.0,
@@ -97,7 +95,6 @@ class TestAnnotateMS2Spectra:
         results = annotate_ms2_spectra(
             spectra=[spectrum],
             proformas=[PEPTIDE_PROFORMA],
-            seq_lens=[PEPTIDE_SEQ_LEN],
             fragmentation_model="cidhcd",
             mass_mode="monoisotopic",
             tolerance_value=20.0,
@@ -114,7 +111,6 @@ class TestAnnotateMS2Spectra:
         results = annotate_ms2_spectra(
             spectra=[spectrum],
             proformas=[PEPTIDE_PROFORMA],
-            seq_lens=[PEPTIDE_SEQ_LEN],
             fragmentation_model="cidhcd",
             mass_mode="monoisotopic",
             tolerance_value=20.0,
@@ -131,7 +127,6 @@ class TestAnnotateMS2Spectra:
         results = annotate_ms2_spectra(
             spectra=[spectrum],
             proformas=[PEPTIDE_PROFORMA],
-            seq_lens=[PEPTIDE_SEQ_LEN],
             fragmentation_model="cidhcd",
             mass_mode="monoisotopic",
             tolerance_value=0.02,
@@ -148,7 +143,6 @@ class TestAnnotateMS2Spectra:
         results = annotate_ms2_spectra(
             spectra=[spectrum],
             proformas=[PEPTIDE_PROFORMA],
-            seq_lens=[PEPTIDE_SEQ_LEN],
             fragmentation_model="etd",
             mass_mode="monoisotopic",
             tolerance_value=20.0,
@@ -167,7 +161,6 @@ class TestAnnotateMS2Spectra:
         results = annotate_ms2_spectra(
             spectra=spectra,
             proformas=[PEPTIDE_PROFORMA, PEPTIDE_PROFORMA],
-            seq_lens=[PEPTIDE_SEQ_LEN, PEPTIDE_SEQ_LEN],
             fragmentation_model="cidhcd",
             mass_mode="monoisotopic",
             tolerance_value=20.0,
@@ -187,7 +180,6 @@ class TestAnnotateMS2Spectra:
         results = annotate_ms2_spectra(
             spectra=[spectrum],
             proformas=[PEPTIDE_PROFORMA],
-            seq_lens=[PEPTIDE_SEQ_LEN],
             fragmentation_model="cidhcd",
             mass_mode="monoisotopic",
             tolerance_value=20.0,
@@ -208,7 +200,6 @@ class TestAnnotateMS2Spectra:
             annotate_ms2_spectra(
                 spectra=[spectrum],
                 proformas=[PEPTIDE_PROFORMA],
-                seq_lens=[PEPTIDE_SEQ_LEN],
                 fragmentation_model="cidhcd",
                 mass_mode="monoisotopic",
                 tolerance_value=20.0,
@@ -223,7 +214,6 @@ class TestAnnotateMS2Spectra:
             annotate_ms2_spectra(
                 spectra=[spectrum],
                 proformas=[PEPTIDE_PROFORMA, PEPTIDE_PROFORMA],
-                seq_lens=[PEPTIDE_SEQ_LEN],
                 fragmentation_model="cidhcd",
                 mass_mode="monoisotopic",
                 tolerance_value=20.0,
@@ -384,7 +374,6 @@ class TestScoreMS2Spectra:
         annotated = annotate_ms2_spectra(
             spectra=[spectrum],
             proformas=[PEPTIDE_PROFORMA],
-            seq_lens=[PEPTIDE_SEQ_LEN],
             fragmentation_model="cidhcd",
             mass_mode="monoisotopic",
             tolerance_value=20.0,

--- a/uv.lock
+++ b/uv.lock
@@ -1,11 +1,9 @@
 version = 1
 revision = 3
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
-    "python_full_version == '3.10.*'",
-    "python_full_version == '3.9.*'",
-    "python_full_version < '3.9'",
+    "python_full_version < '3.11'",
 ]
 
 [[package]]
@@ -22,8 +20,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -32,25 +29,8 @@ wheels = [
 
 [[package]]
 name = "iniconfig"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.9.*'",
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
-]
-
-[[package]]
-name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -60,17 +40,13 @@ wheels = [
 name = "ms2rescore-rs"
 source = { editable = "." }
 dependencies = [
-    { name = "numpy", version = "1.24.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.optional-dependencies]
 test = [
-    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -82,103 +58,10 @@ provides-extras = ["test"]
 
 [[package]]
 name = "numpy"
-version = "1.24.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz", hash = "sha256:80f5e3a4e498641401868df4208b74581206afbee7cf7b8329daae82676d9463", size = 10911229, upload-time = "2023-06-26T13:39:33.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/80/6cdfb3e275d95155a34659163b83c09e3a3ff9f1456880bec6cc63d71083/numpy-1.24.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0bfb52d2169d58c1cdb8cc1f16989101639b34c7d3ce60ed70b19c63eba0b64", size = 19789140, upload-time = "2023-06-26T13:22:33.184Z" },
-    { url = "https://files.pythonhosted.org/packages/64/5f/3f01d753e2175cfade1013eea08db99ba1ee4bdb147ebcf3623b75d12aa7/numpy-1.24.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed094d4f0c177b1b8e7aa9cba7d6ceed51c0e569a5318ac0ca9a090680a6a1b1", size = 13854297, upload-time = "2023-06-26T13:22:59.541Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/b3/2f9c21d799fa07053ffa151faccdceeb69beec5a010576b8991f614021f7/numpy-1.24.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79fc682a374c4a8ed08b331bef9c5f582585d1048fa6d80bc6c35bc384eee9b4", size = 13995611, upload-time = "2023-06-26T13:23:22.167Z" },
-    { url = "https://files.pythonhosted.org/packages/10/be/ae5bf4737cb79ba437879915791f6f26d92583c738d7d960ad94e5c36adf/numpy-1.24.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ffe43c74893dbf38c2b0a1f5428760a1a9c98285553c89e12d70a96a7f3a4d6", size = 17282357, upload-time = "2023-06-26T13:23:51.446Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/64/908c1087be6285f40e4b3e79454552a701664a079321cff519d8c7051d06/numpy-1.24.4-cp310-cp310-win32.whl", hash = "sha256:4c21decb6ea94057331e111a5bed9a79d335658c27ce2adb580fb4d54f2ad9bc", size = 12429222, upload-time = "2023-06-26T13:24:13.849Z" },
-    { url = "https://files.pythonhosted.org/packages/22/55/3d5a7c1142e0d9329ad27cece17933b0e2ab4e54ddc5c1861fbfeb3f7693/numpy-1.24.4-cp310-cp310-win_amd64.whl", hash = "sha256:b4bea75e47d9586d31e892a7401f76e909712a0fd510f58f5337bea9572c571e", size = 14841514, upload-time = "2023-06-26T13:24:38.129Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/cc/5ed2280a27e5dab12994c884f1f4d8c3bd4d885d02ae9e52a9d213a6a5e2/numpy-1.24.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f136bab9c2cfd8da131132c2cf6cc27331dd6fae65f95f69dcd4ae3c3639c810", size = 19775508, upload-time = "2023-06-26T13:25:08.882Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/bc/77635c657a3668cf652806210b8662e1aff84b818a55ba88257abf6637a8/numpy-1.24.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e2926dac25b313635e4d6cf4dc4e51c8c0ebfed60b801c799ffc4c32bf3d1254", size = 13840033, upload-time = "2023-06-26T13:25:33.417Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/4c/96cdaa34f54c05e97c1c50f39f98d608f96f0677a6589e64e53104e22904/numpy-1.24.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:222e40d0e2548690405b0b3c7b21d1169117391c2e82c378467ef9ab4c8f0da7", size = 13991951, upload-time = "2023-06-26T13:25:55.725Z" },
-    { url = "https://files.pythonhosted.org/packages/22/97/dfb1a31bb46686f09e68ea6ac5c63fdee0d22d7b23b8f3f7ea07712869ef/numpy-1.24.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7215847ce88a85ce39baf9e89070cb860c98fdddacbaa6c0da3ffb31b3350bd5", size = 17278923, upload-time = "2023-06-26T13:26:25.658Z" },
-    { url = "https://files.pythonhosted.org/packages/35/e2/76a11e54139654a324d107da1d98f99e7aa2a7ef97cfd7c631fba7dbde71/numpy-1.24.4-cp311-cp311-win32.whl", hash = "sha256:4979217d7de511a8d57f4b4b5b2b965f707768440c17cb70fbf254c4b225238d", size = 12422446, upload-time = "2023-06-26T13:26:49.302Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/ec/ebef2f7d7c28503f958f0f8b992e7ce606fb74f9e891199329d5f5f87404/numpy-1.24.4-cp311-cp311-win_amd64.whl", hash = "sha256:b7b1fc9864d7d39e28f41d089bfd6353cb5f27ecd9905348c24187a768c79694", size = 14834466, upload-time = "2023-06-26T13:27:16.029Z" },
-    { url = "https://files.pythonhosted.org/packages/11/10/943cfb579f1a02909ff96464c69893b1d25be3731b5d3652c2e0cf1281ea/numpy-1.24.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1452241c290f3e2a312c137a9999cdbf63f78864d63c79039bda65ee86943f61", size = 19780722, upload-time = "2023-06-26T13:27:49.573Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/ae/f53b7b265fdc701e663fbb322a8e9d4b14d9cb7b2385f45ddfabfc4327e4/numpy-1.24.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:04640dab83f7c6c85abf9cd729c5b65f1ebd0ccf9de90b270cd61935eef0197f", size = 13843102, upload-time = "2023-06-26T13:28:12.288Z" },
-    { url = "https://files.pythonhosted.org/packages/25/6f/2586a50ad72e8dbb1d8381f837008a0321a3516dfd7cb57fc8cf7e4bb06b/numpy-1.24.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5425b114831d1e77e4b5d812b69d11d962e104095a5b9c3b641a218abcc050e", size = 14039616, upload-time = "2023-06-26T13:28:35.659Z" },
-    { url = "https://files.pythonhosted.org/packages/98/5d/5738903efe0ecb73e51eb44feafba32bdba2081263d40c5043568ff60faf/numpy-1.24.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd80e219fd4c71fc3699fc1dadac5dcf4fd882bfc6f7ec53d30fa197b8ee22dc", size = 17316263, upload-time = "2023-06-26T13:29:09.272Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/57/8d328f0b91c733aa9aa7ee540dbc49b58796c862b4fbcb1146c701e888da/numpy-1.24.4-cp38-cp38-win32.whl", hash = "sha256:4602244f345453db537be5314d3983dbf5834a9701b7723ec28923e2889e0bb2", size = 12455660, upload-time = "2023-06-26T13:29:33.434Z" },
-    { url = "https://files.pythonhosted.org/packages/69/65/0d47953afa0ad569d12de5f65d964321c208492064c38fe3b0b9744f8d44/numpy-1.24.4-cp38-cp38-win_amd64.whl", hash = "sha256:692f2e0f55794943c5bfff12b3f56f99af76f902fc47487bdfe97856de51a706", size = 14868112, upload-time = "2023-06-26T13:29:58.385Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/cd/d5b0402b801c8a8b56b04c1e85c6165efab298d2f0ab741c2406516ede3a/numpy-1.24.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2541312fbf09977f3b3ad449c4e5f4bb55d0dbf79226d7724211acc905049400", size = 19816549, upload-time = "2023-06-26T13:30:36.976Z" },
-    { url = "https://files.pythonhosted.org/packages/14/27/638aaa446f39113a3ed38b37a66243e21b38110d021bfcb940c383e120f2/numpy-1.24.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9667575fb6d13c95f1b36aca12c5ee3356bf001b714fc354eb5465ce1609e62f", size = 13879950, upload-time = "2023-06-26T13:31:01.787Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/27/91894916e50627476cff1a4e4363ab6179d01077d71b9afed41d9e1f18bf/numpy-1.24.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a86ed21e4f87050382c7bc96571755193c4c1392490744ac73d660e8f564a9", size = 14030228, upload-time = "2023-06-26T13:31:26.696Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/7c/d7b2a0417af6428440c0ad7cb9799073e507b1a465f827d058b826236964/numpy-1.24.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d11efb4dbecbdf22508d55e48d9c8384db795e1b7b51ea735289ff96613ff74d", size = 17311170, upload-time = "2023-06-26T13:31:56.615Z" },
-    { url = "https://files.pythonhosted.org/packages/18/9d/e02ace5d7dfccee796c37b995c63322674daf88ae2f4a4724c5dd0afcc91/numpy-1.24.4-cp39-cp39-win32.whl", hash = "sha256:6620c0acd41dbcb368610bb2f4d83145674040025e5536954782467100aa8835", size = 12454918, upload-time = "2023-06-26T13:32:16.8Z" },
-    { url = "https://files.pythonhosted.org/packages/63/38/6cc19d6b8bfa1d1a459daf2b3fe325453153ca7019976274b6f33d8b5663/numpy-1.24.4-cp39-cp39-win_amd64.whl", hash = "sha256:befe2bf740fd8373cf56149a5c23a0f601e82869598d41f8e188a0e9869926f8", size = 14867441, upload-time = "2023-06-26T13:32:40.521Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/fd/8dff40e25e937c94257455c237b9b6bf5a30d42dd1cc11555533be099492/numpy-1.24.4-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:31f13e25b4e304632a4619d0e0777662c2ffea99fcae2029556b17d8ff958aef", size = 19156590, upload-time = "2023-06-26T13:33:10.36Z" },
-    { url = "https://files.pythonhosted.org/packages/42/e7/4bf953c6e05df90c6d351af69966384fed8e988d0e8c54dad7103b59f3ba/numpy-1.24.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95f7ac6540e95bc440ad77f56e520da5bf877f87dca58bd095288dce8940532a", size = 16705744, upload-time = "2023-06-26T13:33:36.703Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/dd/9106005eb477d022b60b3817ed5937a43dad8fd1f20b0610ea8a32fcb407/numpy-1.24.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:e98f220aa76ca2a977fe435f5b04d7b3470c0a2e6312907b37ba6068f26787f2", size = 14734290, upload-time = "2023-06-26T13:34:05.409Z" },
-]
-
-[[package]]
-name = "numpy"
-version = "2.0.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.9.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/75/10dd1f8116a8b796cb2c737b674e02d02e80454bda953fa7e65d8c12b016/numpy-2.0.2.tar.gz", hash = "sha256:883c987dee1880e2a864ab0dc9892292582510604156762362d9326444636e78", size = 18902015, upload-time = "2024-08-26T20:19:40.945Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/91/3495b3237510f79f5d81f2508f9f13fea78ebfdf07538fc7444badda173d/numpy-2.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:51129a29dbe56f9ca83438b706e2e69a39892b5eda6cedcb6b0c9fdc9b0d3ece", size = 21165245, upload-time = "2024-08-26T20:04:14.625Z" },
-    { url = "https://files.pythonhosted.org/packages/05/33/26178c7d437a87082d11019292dce6d3fe6f0e9026b7b2309cbf3e489b1d/numpy-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f15975dfec0cf2239224d80e32c3170b1d168335eaedee69da84fbe9f1f9cd04", size = 13738540, upload-time = "2024-08-26T20:04:36.784Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/31/cc46e13bf07644efc7a4bf68df2df5fb2a1a88d0cd0da9ddc84dc0033e51/numpy-2.0.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:8c5713284ce4e282544c68d1c3b2c7161d38c256d2eefc93c1d683cf47683e66", size = 5300623, upload-time = "2024-08-26T20:04:46.491Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/16/7bfcebf27bb4f9d7ec67332ffebee4d1bf085c84246552d52dbb548600e7/numpy-2.0.2-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:becfae3ddd30736fe1889a37f1f580e245ba79a5855bff5f2a29cb3ccc22dd7b", size = 6901774, upload-time = "2024-08-26T20:04:58.173Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/a3/561c531c0e8bf082c5bef509d00d56f82e0ea7e1e3e3a7fc8fa78742a6e5/numpy-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2da5960c3cf0df7eafefd806d4e612c5e19358de82cb3c343631188991566ccd", size = 13907081, upload-time = "2024-08-26T20:05:19.098Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/66/f7177ab331876200ac7563a580140643d1179c8b4b6a6b0fc9838de2a9b8/numpy-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:496f71341824ed9f3d2fd36cf3ac57ae2e0165c143b55c3a035ee219413f3318", size = 19523451, upload-time = "2024-08-26T20:05:47.479Z" },
-    { url = "https://files.pythonhosted.org/packages/25/7f/0b209498009ad6453e4efc2c65bcdf0ae08a182b2b7877d7ab38a92dc542/numpy-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a61ec659f68ae254e4d237816e33171497e978140353c0c2038d46e63282d0c8", size = 19927572, upload-time = "2024-08-26T20:06:17.137Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/df/2619393b1e1b565cd2d4c4403bdd979621e2c4dea1f8532754b2598ed63b/numpy-2.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d731a1c6116ba289c1e9ee714b08a8ff882944d4ad631fd411106a30f083c326", size = 14400722, upload-time = "2024-08-26T20:06:39.16Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ad/77e921b9f256d5da36424ffb711ae79ca3f451ff8489eeca544d0701d74a/numpy-2.0.2-cp310-cp310-win32.whl", hash = "sha256:984d96121c9f9616cd33fbd0618b7f08e0cfc9600a7ee1d6fd9b239186d19d97", size = 6472170, upload-time = "2024-08-26T20:06:50.361Z" },
-    { url = "https://files.pythonhosted.org/packages/10/05/3442317535028bc29cf0c0dd4c191a4481e8376e9f0db6bcf29703cadae6/numpy-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:c7b0be4ef08607dd04da4092faee0b86607f111d5ae68036f16cc787e250a131", size = 15905558, upload-time = "2024-08-26T20:07:13.881Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cf/034500fb83041aa0286e0fb16e7c76e5c8b67c0711bb6e9e9737a717d5fe/numpy-2.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:49ca4decb342d66018b01932139c0961a8f9ddc7589611158cb3c27cbcf76448", size = 21169137, upload-time = "2024-08-26T20:07:45.345Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d9/32de45561811a4b87fbdee23b5797394e3d1504b4a7cf40c10199848893e/numpy-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:11a76c372d1d37437857280aa142086476136a8c0f373b2e648ab2c8f18fb195", size = 13703552, upload-time = "2024-08-26T20:08:06.666Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/ca/2f384720020c7b244d22508cb7ab23d95f179fcfff33c31a6eeba8d6c512/numpy-2.0.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:807ec44583fd708a21d4a11d94aedf2f4f3c3719035c76a2bbe1fe8e217bdc57", size = 5298957, upload-time = "2024-08-26T20:08:15.83Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/78/a3e4f9fb6aa4e6fdca0c5428e8ba039408514388cf62d89651aade838269/numpy-2.0.2-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8cafab480740e22f8d833acefed5cc87ce276f4ece12fdaa2e8903db2f82897a", size = 6905573, upload-time = "2024-08-26T20:08:27.185Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/72/cfc3a1beb2caf4efc9d0b38a15fe34025230da27e1c08cc2eb9bfb1c7231/numpy-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a15f476a45e6e5a3a79d8a14e62161d27ad897381fecfa4a09ed5322f2085669", size = 13914330, upload-time = "2024-08-26T20:08:48.058Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/a8/c17acf65a931ce551fee11b72e8de63bf7e8a6f0e21add4c937c83563538/numpy-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13e689d772146140a252c3a28501da66dfecd77490b498b168b501835041f951", size = 19534895, upload-time = "2024-08-26T20:09:16.536Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/86/8767f3d54f6ae0165749f84648da9dcc8cd78ab65d415494962c86fac80f/numpy-2.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9ea91dfb7c3d1c56a0e55657c0afb38cf1eeae4544c208dc465c3c9f3a7c09f9", size = 19937253, upload-time = "2024-08-26T20:09:46.263Z" },
-    { url = "https://files.pythonhosted.org/packages/df/87/f76450e6e1c14e5bb1eae6836478b1028e096fd02e85c1c37674606ab752/numpy-2.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c1c9307701fec8f3f7a1e6711f9089c06e6284b3afbbcd259f7791282d660a15", size = 14414074, upload-time = "2024-08-26T20:10:08.483Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ca/0f0f328e1e59f73754f06e1adfb909de43726d4f24c6a3f8805f34f2b0fa/numpy-2.0.2-cp311-cp311-win32.whl", hash = "sha256:a392a68bd329eafac5817e5aefeb39038c48b671afd242710b451e76090e81f4", size = 6470640, upload-time = "2024-08-26T20:10:19.732Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/57/3a3f14d3a759dcf9bf6e9eda905794726b758819df4663f217d658a58695/numpy-2.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:286cd40ce2b7d652a6f22efdfc6d1edf879440e53e76a75955bc0c826c7e64dc", size = 15910230, upload-time = "2024-08-26T20:10:43.413Z" },
-    { url = "https://files.pythonhosted.org/packages/45/40/2e117be60ec50d98fa08c2f8c48e09b3edea93cfcabd5a9ff6925d54b1c2/numpy-2.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:df55d490dea7934f330006d0f81e8551ba6010a5bf035a249ef61a94f21c500b", size = 20895803, upload-time = "2024-08-26T20:11:13.916Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/1b8b8dee833f53cef3e0a3f69b2374467789e0bb7399689582314df02651/numpy-2.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8df823f570d9adf0978347d1f926b2a867d5608f434a7cff7f7908c6570dcf5e", size = 13471835, upload-time = "2024-08-26T20:11:34.779Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/19/e2793bde475f1edaea6945be141aef6c8b4c669b90c90a300a8954d08f0a/numpy-2.0.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9a92ae5c14811e390f3767053ff54eaee3bf84576d99a2456391401323f4ec2c", size = 5038499, upload-time = "2024-08-26T20:11:43.902Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/ff/ddf6dac2ff0dd50a7327bcdba45cb0264d0e96bb44d33324853f781a8f3c/numpy-2.0.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:a842d573724391493a97a62ebbb8e731f8a5dcc5d285dfc99141ca15a3302d0c", size = 6633497, upload-time = "2024-08-26T20:11:55.09Z" },
-    { url = "https://files.pythonhosted.org/packages/72/21/67f36eac8e2d2cd652a2e69595a54128297cdcb1ff3931cfc87838874bd4/numpy-2.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05e238064fc0610c840d1cf6a13bf63d7e391717d247f1bf0318172e759e692", size = 13621158, upload-time = "2024-08-26T20:12:14.95Z" },
-    { url = "https://files.pythonhosted.org/packages/39/68/e9f1126d757653496dbc096cb429014347a36b228f5a991dae2c6b6cfd40/numpy-2.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0123ffdaa88fa4ab64835dcbde75dcdf89c453c922f18dced6e27c90d1d0ec5a", size = 19236173, upload-time = "2024-08-26T20:12:44.049Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/e9/1f5333281e4ebf483ba1c888b1d61ba7e78d7e910fdd8e6499667041cc35/numpy-2.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:96a55f64139912d61de9137f11bf39a55ec8faec288c75a54f93dfd39f7eb40c", size = 19634174, upload-time = "2024-08-26T20:13:13.634Z" },
-    { url = "https://files.pythonhosted.org/packages/71/af/a469674070c8d8408384e3012e064299f7a2de540738a8e414dcfd639996/numpy-2.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ec9852fb39354b5a45a80bdab5ac02dd02b15f44b3804e9f00c556bf24b4bded", size = 14099701, upload-time = "2024-08-26T20:13:34.851Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/3d/08ea9f239d0e0e939b6ca52ad403c84a2bce1bde301a8eb4888c1c1543f1/numpy-2.0.2-cp312-cp312-win32.whl", hash = "sha256:671bec6496f83202ed2d3c8fdc486a8fc86942f2e69ff0e986140339a63bcbe5", size = 6174313, upload-time = "2024-08-26T20:13:45.653Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/b5/4ac39baebf1fdb2e72585c8352c56d063b6126be9fc95bd2bb5ef5770c20/numpy-2.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:cfd41e13fdc257aa5778496b8caa5e856dc4896d4ccf01841daee1d96465467a", size = 15606179, upload-time = "2024-08-26T20:14:08.786Z" },
-    { url = "https://files.pythonhosted.org/packages/43/c1/41c8f6df3162b0c6ffd4437d729115704bd43363de0090c7f913cfbc2d89/numpy-2.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9059e10581ce4093f735ed23f3b9d283b9d517ff46009ddd485f1747eb22653c", size = 21169942, upload-time = "2024-08-26T20:14:40.108Z" },
-    { url = "https://files.pythonhosted.org/packages/39/bc/fd298f308dcd232b56a4031fd6ddf11c43f9917fbc937e53762f7b5a3bb1/numpy-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:423e89b23490805d2a5a96fe40ec507407b8ee786d66f7328be214f9679df6dd", size = 13711512, upload-time = "2024-08-26T20:15:00.985Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ff/06d1aa3eeb1c614eda245c1ba4fb88c483bee6520d361641331872ac4b82/numpy-2.0.2-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:2b2955fa6f11907cf7a70dab0d0755159bca87755e831e47932367fc8f2f2d0b", size = 5306976, upload-time = "2024-08-26T20:15:10.876Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/98/121996dcfb10a6087a05e54453e28e58694a7db62c5a5a29cee14c6e047b/numpy-2.0.2-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:97032a27bd9d8988b9a97a8c4d2c9f2c15a81f61e2f21404d7e8ef00cb5be729", size = 6906494, upload-time = "2024-08-26T20:15:22.055Z" },
-    { url = "https://files.pythonhosted.org/packages/15/31/9dffc70da6b9bbf7968f6551967fc21156207366272c2a40b4ed6008dc9b/numpy-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e795a8be3ddbac43274f18588329c72939870a16cae810c2b73461c40718ab1", size = 13912596, upload-time = "2024-08-26T20:15:42.452Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/14/78635daab4b07c0930c919d451b8bf8c164774e6a3413aed04a6d95758ce/numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26b258c385842546006213344c50655ff1555a9338e2e5e02a0756dc3e803dd", size = 19526099, upload-time = "2024-08-26T20:16:11.048Z" },
-    { url = "https://files.pythonhosted.org/packages/26/4c/0eeca4614003077f68bfe7aac8b7496f04221865b3a5e7cb230c9d055afd/numpy-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fec9451a7789926bcf7c2b8d187292c9f93ea30284802a0ab3f5be8ab36865d", size = 19932823, upload-time = "2024-08-26T20:16:40.171Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/46/ea25b98b13dccaebddf1a803f8c748680d972e00507cd9bc6dcdb5aa2ac1/numpy-2.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9189427407d88ff25ecf8f12469d4d39d35bee1db5d39fc5c168c6f088a6956d", size = 14404424, upload-time = "2024-08-26T20:17:02.604Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/a6/177dd88d95ecf07e722d21008b1b40e681a929eb9e329684d449c36586b2/numpy-2.0.2-cp39-cp39-win32.whl", hash = "sha256:905d16e0c60200656500c95b6b8dca5d109e23cb24abc701d41c02d74c6b3afa", size = 6476809, upload-time = "2024-08-26T20:17:13.553Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2b/7fc9f4e7ae5b507c1a3a21f0f15ed03e794c1242ea8a242ac158beb56034/numpy-2.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:a3f4ab0caa7f053f6797fcd4e1e25caee367db3112ef2b6ef82d749530768c73", size = 15911314, upload-time = "2024-08-26T20:17:36.72Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3b/df5a870ac6a3be3a86856ce195ef42eec7ae50d2a202be1f5a4b3b340e14/numpy-2.0.2-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7f0a0c6f12e07fa94133c8a67404322845220c06a9e80e85999afe727f7438b8", size = 21025288, upload-time = "2024-08-26T20:18:07.732Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/97/51af92f18d6f6f2d9ad8b482a99fb74e142d71372da5d834b3a2747a446e/numpy-2.0.2-pp39-pypy39_pp73-macosx_14_0_x86_64.whl", hash = "sha256:312950fdd060354350ed123c0e25a71327d3711584beaef30cdaa93320c392d4", size = 6762793, upload-time = "2024-08-26T20:18:19.125Z" },
-    { url = "https://files.pythonhosted.org/packages/12/46/de1fbd0c1b5ccaa7f9a005b66761533e2f6a3e560096682683a223631fe9/numpy-2.0.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26df23238872200f63518dd2aa984cfca675d82469535dc7162dc2ee52d9dd5c", size = 19334885, upload-time = "2024-08-26T20:18:47.237Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/dc/d330a6faefd92b446ec0f0dfea4c3207bb1fef3c4771d19cf4543efd2c78/numpy-2.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a46288ec55ebbd58947d31d72be2c63cbf839f0a63b49cb755022310792a3385", size = 15828784, upload-time = "2024-08-26T20:19:11.19Z" },
-]
-
-[[package]]
-name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*'",
+    "python_full_version < '3.11'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -331,25 +214,8 @@ wheels = [
 
 [[package]]
 name = "pluggy"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
-]
-
-[[package]]
-name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version == '3.10.*'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -366,61 +232,16 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.5"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.9' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.9'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "packaging", marker = "python_full_version < '3.9'" },
-    { name = "pluggy", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "tomli", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
-]
-
-[[package]]
-name = "pytest"
-version = "8.4.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.9.*'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version == '3.9.*' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version == '3.9.*'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "packaging", marker = "python_full_version == '3.9.*'" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "pygments", marker = "python_full_version == '3.9.*'" },
-    { name = "tomli", marker = "python_full_version == '3.9.*'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
-]
-
-[[package]]
-name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pygments", marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
@@ -483,24 +304,8 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
-]
-
-[[package]]
-name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.10.*'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },


### PR DESCRIPTION
## Added

- Added `ms2pip_extract_targets`, a Rust-backed API for extracting per-ion observed intensity arrays from `AnnotatedMS2Spectrum` objects.
- Added shared utilities for cached theoretical fragment generation and nearest-peak m/z matching.
- Registered the new ms2pip targets module/function in the Python extension API.

## Changed

- Bumped the crate version to `0.5.0-alpha.3`.
- Updated `annotate_ms2_spectra` to derive sequence length internally from the ProForma input and removed the need to pass `seq_lens`.
- Parallelized fragment-cache construction in `annotate_ms2_spectra` so cache building and annotation both run outside the GIL.
- Reworked `annotate_ms2_spectra` to build peak annotations directly from cached fragment metadata instead of materializing intermediate `rustyms` spectrum types.
- Updated `ms2pip_compute_theoretical_mz` to return NumPy `float32` arrays directly instead of Rust `Vec<f64>` output that must be wrapped on the Python side.
- Simplified theoretical m/z generation by pre-parsing requested ion types and filling indexed `f32` output buffers directly.
- Refreshed `uv.lock` to match the current Python support matrix and dependency resolution.

## Fixed

- Fixed target extraction to use explicit `seq_lens` instead of deriving sequence length from matched annotations.
- Fixed target extraction bounds handling by filtering out-of-range annotation positions during GIL-side data extraction.
- Improved target extraction lookup efficiency by using a `HashSet` for ion-type membership checks.
- Eliminated redundant ProForma parsing in the annotation pipeline by deriving `seq_len` from cached entries.
- Corrected the theoretical m/z docstring to reflect that NumPy arrays are returned.
- Reduced native overhead in the correlate workflow by avoiding unnecessary `rustyms` spectrum materialization and intermediate allocations.

## Removed

- Removed the `seq_lens` parameter from `annotate_ms2_spectra`.
