### PR TITLE
Pre-release fixes, version bump, CHANGELOG, and README for 0.5.0-beta.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,12 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
+      - name: Set up MSVC environment
+        if: matrix.platform == 'windows'
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Set cmake generator for Windows
+        if: matrix.platform == 'windows'
+        run: echo "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
+      - name: Set up MSVC environment
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Set cmake generator for Windows
+        if: runner.os == 'Windows'
+        run: echo "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
       - name: Install Python
         uses: actions/setup-python@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,96 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0-beta.1] - 2026-06-18
+
+### Added
+- `annotate_ms2_spectra`: annotate MS2 spectra with theoretical fragment ions
+  (tolerance in Da or ppm, configurable fragmentation model and mass mode)
+- `score_ms2_spectra`: compute per-ion-series MS2 scoring features (matched
+  ions, longest sequence, explained intensity) with optional hyperscore
+- `ms2pip_compute_features`: compute 139 MS2PIP XGBoost feature vectors per
+  cleavage site from ProForma peptide strings
+- `ms2pip_compute_theoretical_mz`: compute theoretical fragment m/z arrays
+  (numpy float32) for arbitrary ion types and charges
+- `ms2pip_extract_targets`: extract per-ion-type observed intensity arrays
+  from annotated spectra for model training
+- `AnnotatedMS2Spectrum` and `FragmentAnnotation` types with pickle support
+- Codebase restructured into `types/`, `io/`, `scoring/`, and `ms2pip/` modules
+- ARM64 wheel builds for Windows and macOS
+
+## [0.4.3] - 2025-09-30
+
+### Fixed
+- Crash on empty spectra (contributed by @di-hardt)
+
+### Changed
+- Updated mzdata to 0.59.2
+
+## [0.4.2] - 2025-04-01
+
+### Changed
+- Updated mzdata to 0.48.3
+
+## [0.4.1] - 2025-01-15
+
+### Fixed
+- Thermo RAW files without pre-centroided peaks now read correctly (vendor
+  centroiding is now requested explicitly)
+
+### Changed
+- Updated timsrust to 0.4
+
+## [0.4.0-1] - 2024-11-20
+
+### Changed
+- Added Python 3.13 wheel builds
+
+## [0.4.0] - 2024-10-24
+
+### Added
+- Thermo RAW file support via mzdata
+- `is_supported_file_type` utility function
+
+### Changed
+- Dropped x86 Linux wheel builds
+- Updated mzdata
+
+## [0.3.0] - 2024-07-17
+
+### Changed
+- Updated timsrust to 0.3.0
+
+## [0.2.1] - 2024-07-01
+
+### Added
+- Tests for `get_ms2_spectra`
+
+### Changed
+- Updated mzdata to 0.20.0
+
+## [0.2.0] - 2024-04-08
+
+### Added
+- `get_ms2_spectra`: read MS2 spectra from spectrum files
+
+## [0.1.0] - 2024-04-05
+
+### Added
+- Initial release: `get_precursor_info` for mzML, MGF, and Bruker TDF files
+
+[Unreleased]: https://github.com/compomics/ms2rescore-rs/compare/v0.5.0-beta.1...HEAD
+[0.5.0-beta.1]: https://github.com/compomics/ms2rescore-rs/compare/v0.4.3...v0.5.0-beta.1
+[0.4.3]: https://github.com/compomics/ms2rescore-rs/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/compomics/ms2rescore-rs/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/compomics/ms2rescore-rs/compare/v0.4.0-1...v0.4.1
+[0.4.0-1]: https://github.com/compomics/ms2rescore-rs/compare/v0.4.0...v0.4.0-1
+[0.4.0]: https://github.com/compomics/ms2rescore-rs/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/compomics/ms2rescore-rs/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/compomics/ms2rescore-rs/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/compomics/ms2rescore-rs/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/compomics/ms2rescore-rs/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "ms2rescore-rs"
-version = "0.5.0-alpha.3"
+version = "0.5.0-beta.1"
 dependencies = [
  "mzdata",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms2rescore-rs"
-version = "0.5.0-alpha.3"
+version = "0.5.0-beta.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # ms2rescore-rs
-Rust functionality for the MS²Rescore package
+
+Rust core for [MS²Rescore](https://github.com/compomics/ms2rescore) and
+[MS²PIP](https://github.com/compomics/ms2pip), exposed as a Python package via PyO3.
+
+Provides fast, parallelized implementations of spectrum reading, fragment ion annotation, MS2PIP feature extraction, and MS2 scoring features used during PSM rescoring.
+
+## Installation
+
+```sh
+pip install ms2rescore-rs
+```
+
+## Functions
+
+| Function | Description |
+|---|---|
+| `get_precursor_info(path)` | Read precursor metadata from mzML, MGF, or Bruker raw files |
+| `get_ms2_spectra(path)` | Read MS2 spectra from mzML, MGF, or Bruker raw files |
+| `annotate_ms2_spectra(spectra, proformas, ...)` | Match observed peaks to theoretical fragment ions |
+| `score_ms2_spectra(spectra, seq_lens, ...)` | Compute per-series matched-ion scoring features |
+| `ms2pip_compute_features(proformas, ...)` | Compute 139 MS2PIP XGBoost feature vectors per cleavage site |
+| `ms2pip_compute_theoretical_mz(proformas, ...)` | Compute theoretical fragment m/z arrays |
+| `ms2pip_extract_targets(spectra, intensities, ...)` | Extract observed intensity targets for model training |
+
+Supported input formats: mzML, mzMLb, MGF, Thermo RAW, Bruker TDF/TIMS.
+
+ProForma 2.0 notation is used throughout for peptide sequences and modifications.
+
+## Development
+
+Requires Rust and [maturin](https://github.com/PyO3/maturin).
+
+```sh
+uv run maturin develop
+```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Supported input formats: mzML, mzMLb, MGF, Thermo RAW, Bruker TDF/TIMS.
 
 ProForma 2.0 notation is used throughout for peptide sequences and modifications.
 
+## Built on
+
+- [mzcore (formerly rustyms)](https://github.com/rusteomics/mzcore) — ProForma parsing, theoretical fragment generation, and mass calculations
+- [mzdata](https://github.com/mobiusklein/mzdata) — mzML, mzMLb, MGF, and Thermo RAW file reading
+- [timsrust](https://github.com/MannLabs/timsrust) — Bruker TDF/TIMS file reading
+
 ## Development
 
 Requires Rust and [maturin](https://github.com/PyO3/maturin).

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -52,8 +52,11 @@ fn parse_tolerance(
     }
 }
 
-
 /// Annotate MS2 spectra with theoretical fragment ions.
+///
+/// The charge suffix in the ProForma string (e.g. `PEPTIDE/2`) is used for
+/// fragment generation when present; the spectrum precursor charge is the
+/// fallback when no charge suffix is present in the ProForma string.
 #[pyfunction]
 pub fn annotate_ms2_spectra(
     py: Python<'_>,
@@ -66,7 +69,7 @@ pub fn annotate_ms2_spectra(
 ) -> PyResult<Vec<AnnotatedMS2Spectrum>> {
     let n = spectra.len();
     if proformas.len() != n {
-        return Err(PyException::new_err(
+        return Err(PyValueError::new_err(
             "Input arrays must have identical length: spectra, proformas",
         ));
     }
@@ -100,22 +103,33 @@ pub fn annotate_ms2_spectra(
         let spec_ref = spectra[i].bind(py);
         let spec = spec_ref.borrow();
 
-        let proforma = proformas[i]
-            .split('/')
-            .next()
-            .unwrap_or(&proformas[i])
-            .to_string();
+        let fallback_charge = spec.precursor.as_ref().map(|p| p.charge as i32).unwrap_or(0);
+        let (proforma, precursor_charge) = match proformas[i].split_once('/') {
+            Some((seq, charge_str)) => {
+                let charge = charge_str.trim().parse::<i32>().map_err(|_| {
+                    PyValueError::new_err(format!(
+                        "Invalid charge suffix in ProForma at index {i}: '{}'. \
+                         Expected a positive integer (e.g. 'PEPTIDE/2').",
+                        proformas[i]
+                    ))
+                })?;
+                if charge <= 0 {
+                    return Err(PyValueError::new_err(format!(
+                        "Charge must be a positive integer in ProForma at index {i}: '{}'.",
+                        proformas[i]
+                    )));
+                }
+                (seq.to_string(), charge)
+            }
+            None => (proformas[i].clone(), fallback_charge),
+        };
 
         owned.push(OwnedSpec {
             id: spec.identifier.clone(),
             mz_f32: spec.mz.clone(),
             intensity_f32: spec.intensity.clone(),
             precursor: spec.precursor.clone(),
-            precursor_charge: spec
-                .precursor
-                .as_ref()
-                .map(|p| p.charge as i32)
-                .unwrap_or(0),
+            precursor_charge,
             proforma,
         });
     }
@@ -123,7 +137,8 @@ pub fn annotate_ms2_spectra(
     let model = parse_fragmentation_model(&fragmentation_model)?;
     let mode = parse_mass_mode(&mass_mode)?;
     let tolerance = parse_tolerance(tolerance_value, &tolerance_mode)?;
-    // Precompute theoretical fragments per unique peptidoform+charge
+
+    // Precompute theoretical fragments per unique (bare sequence, charge) pair.
     struct CacheEntry {
         fragments: Vec<crate::utils::CachedFragment>,
         seq_len: usize,
@@ -141,7 +156,7 @@ pub fn annotate_ms2_spectra(
         seen.into_keys().collect()
     };
 
-    // Release GIL and parallelize both cache building and annotation
+    // Release GIL and parallelize both cache building and annotation.
     let results: Result<Vec<AnnotatedMS2Spectrum>, String> = py.detach(|| {
         let frag_cache: FragCache = Arc::new(
             unique_keys
@@ -159,12 +174,10 @@ pub fn annotate_ms2_spectra(
                                 rustyms::system::isize::Charge::new::<rustyms::system::e>(
                                     charge as isize,
                                 );
-                            let fragments =
-                                build_theoretical_fragments(&peptidoform, frag_charge, &model, mode);
-                            CacheEntry {
-                                fragments,
-                                seq_len,
-                            }
+                            let fragments = build_theoretical_fragments(
+                                &peptidoform, frag_charge, &model, mode,
+                            );
+                            CacheEntry { fragments, seq_len }
                         });
                     ((proforma, charge), Arc::new(entry))
                 })
@@ -193,16 +206,9 @@ pub fn annotate_ms2_spectra(
                     _ => return Ok(item.empty_annotated()),
                 };
 
-                let mz_range = MassOverCharge::new::<thomson>(0.0)
-                    ..=MassOverCharge::new::<thomson>(f64::MAX);
                 let mut peak_annotations = vec![Vec::new(); item.mz_f32.len()];
 
                 for frag in &entry.fragments {
-                    let fragment_mz = MassOverCharge::new::<thomson>(frag.mz);
-                    if !mz_range.contains(&fragment_mz) {
-                        continue;
-                    }
-
                     if let Some(idx) = search_sorted_mz(&item.mz_f32, frag.mz, &tolerance) {
                         peak_annotations[idx].push(FragmentAnnotation {
                             series: frag.series.to_string(),

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -4,7 +4,7 @@ mod timsrust;
 
 use std::collections::HashMap;
 
-use pyo3::exceptions::PyException;
+use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::*;
 
 use crate::types::ms2_spectrum::MS2Spectrum;
@@ -27,16 +27,18 @@ pub fn get_precursor_info(
 ) -> PyResult<HashMap<String, Precursor>> {
     let file_type = match_file_type(&spectrum_path);
 
+    // Can't raise PyValueError below in a detached thread, so check here first
+    if matches!(file_type, SpectrumFileType::Unknown) {
+        return Err(PyValueError::new_err("Unsupported file type"));
+    }
+
     let precursors = py.detach(|| match file_type {
         SpectrumFileType::MascotGenericFormat
         | SpectrumFileType::MzML
         | SpectrumFileType::MzMLb
         | SpectrumFileType::ThermoRaw => mzdata::parse_precursor_info(&spectrum_path),
         SpectrumFileType::BrukerRaw => timsrust::parse_precursor_info(&spectrum_path),
-        SpectrumFileType::Unknown => Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Unsupported file type",
-        )),
+        SpectrumFileType::Unknown => unreachable!("handled above"),
     });
 
     match precursors {
@@ -53,16 +55,18 @@ pub fn get_ms2_spectra(
 ) -> PyResult<Vec<MS2Spectrum>> {
     let file_type = match_file_type(&spectrum_path);
 
+    // Can't raise PyValueError below in a detached thread, so check here first
+    if matches!(file_type, SpectrumFileType::Unknown) {
+        return Err(PyValueError::new_err("Unsupported file type"));
+    }
+
     let spectra = py.detach(|| match file_type {
         SpectrumFileType::MascotGenericFormat
         | SpectrumFileType::MzML
         | SpectrumFileType::MzMLb
         | SpectrumFileType::ThermoRaw => mzdata::read_ms2_spectra(&spectrum_path),
         SpectrumFileType::BrukerRaw => timsrust::read_ms2_spectra(&spectrum_path),
-        SpectrumFileType::Unknown => Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Unsupported file type",
-        )),
+        SpectrumFileType::Unknown => unreachable!("handled above"),
     });
 
     match spectra {

--- a/src/ms2pip/targets.rs
+++ b/src/ms2pip/targets.rs
@@ -7,8 +7,9 @@ use rayon::prelude::*;
 
 use crate::types::annotation::AnnotatedMS2Spectrum;
 
-/// Floor value for unmatched ions: log2(0.001)
-const LOG2_FLOOR: f32 = -9.965_784;
+/// Floor value for unmatched ions: log2(0.001). Derived from the canonical
+/// f64 constant to avoid precision drift.
+const LOG2_FLOOR: f32 = crate::utils::LOG2_FLOOR_F64 as f32;
 
 /// Extract per-ion-type observed intensity arrays from annotated spectra.
 ///
@@ -48,6 +49,14 @@ pub fn ms2pip_extract_targets(
 
         let intensities_arr = intensities[i].bind(py);
         let intensities_vec = unsafe { intensities_arr.as_slice()? }.to_vec();
+
+        if intensities_vec.len() != spec.peak_annotations.len() {
+            return Err(PyException::new_err(format!(
+                "Spectrum {i}: intensities length {} != peak count {}",
+                intensities_vec.len(),
+                spec.peak_annotations.len()
+            )));
+        }
 
         let n_ions = seq_lens[i].saturating_sub(1);
         let peak_annotations: Vec<Vec<(String, usize)>> = spec

--- a/src/ms2pip/theoretical_mz.rs
+++ b/src/ms2pip/theoretical_mz.rs
@@ -76,7 +76,13 @@ pub fn ms2pip_compute_theoretical_mz(
                 let peptidoform = CompoundPeptidoformIon::pro_forma(pf, None)
                     .map_err(|e| format!("ProForma at index {i}: {e}"))?;
 
-                let charge = extract_charge(&peptidoform).unwrap_or(1) as isize;
+                let charge = extract_charge(&peptidoform)
+                    .ok_or_else(|| {
+                        format!(
+                            "No charge state found in ProForma at index {i}: '{pf}'. \
+                             MS2PIP requires a charge (e.g. 'PEPTIDE/2')."
+                        )
+                    })? as isize;
 
                 let seq_len = peptidoform
                     .peptidoforms()

--- a/src/scoring/spectrum_prediction.rs
+++ b/src/scoring/spectrum_prediction.rs
@@ -15,7 +15,7 @@ use pyo3::types::{PyAny, PyModule};
 
 use rayon::prelude::*;
 
-const CLIP_LOG2_MIN: f64 = -9.965_784_284_662_087; // (0.001_f64).log2()
+const CLIP_LOG2_MIN: f64 = crate::utils::LOG2_FLOOR_F64; // (0.001_f64).log2()
 
 #[inline]
 fn clip_min_f32(x: f32) -> f64 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,6 +16,10 @@ pub struct CachedFragment {
     pub mz: f64,
 }
 
+/// Floor value for log2-intensity clipping and unmatched-ion fill: log2(0.001).
+/// Single source of truth; f32 consumers cast at use site.
+pub const LOG2_FLOOR_F64: f64 = -9.965_784_284_662_087;
+
 /// Compute ln(n!). For typical peptide-length inputs (n < 50) the
 /// iterative sum is fast enough; a lookup table is not warranted.
 pub fn ln_factorial(n: usize) -> f64 {

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -76,3 +76,10 @@ def test_get_ms2_spectra_bruker_minitdf():
     assert spectrum.identifier == "1"
     assert spectrum.mz[0] == pytest.approx(190.1070556640625, 0.0001)
     assert spectrum.intensity[0] == pytest.approx(350.0, 0.0001)
+
+
+def test_unsupported_file_type_raises_value_error():
+    with pytest.raises(ValueError, match="Unsupported file type"):
+        get_ms2_spectra("tests/data/test.unsupported")
+    with pytest.raises(ValueError, match="Unsupported file type"):
+        get_precursor_info("tests/data/test.unsupported")

--- a/tests/test_ms2pip.py
+++ b/tests/test_ms2pip.py
@@ -190,13 +190,12 @@ class TestMs2pipComputeTheoreticalMz:
         assert "b" in result[0]
         assert "y" not in result[0]
 
-    def test_no_charge_defaults(self):
-        """Without charge, should still compute m/z (defaults to charge 1)."""
-        result = ms2pip_compute_theoretical_mz(
-            ["ACDE"], ["b", "y"], "cidhcd", "monoisotopic"
-        )
-        assert len(result[0]["b"]) == 3
-        assert all(v > 0 for v in result[0]["b"])
+    def test_no_charge_raises(self):
+        """Without a charge state, should raise (parity with feature computation)."""
+        with pytest.raises(ValueError, match="No charge state"):
+            ms2pip_compute_theoretical_mz(
+                ["ACDE"], ["b", "y"], "cidhcd", "monoisotopic"
+            )
 
     def test_invalid_proforma_raises(self):
         """Invalid ProForma should raise."""


### PR DESCRIPTION
Pre-release review of `release/0.5` before the first beta tag. Covers correctness fixes, a version bump, and documentation.

### Fixed

- `get_precursor_info` / `get_ms2_spectra`: restore `ValueError` (not `Exception`) for unsupported file types — regression from the io refactor
- `ms2pip_compute_theoretical_mz`: raise `ValueError` on missing ProForma charge instead of silently defaulting to 1, matching the behavior of `ms2pip_compute_features`
- `annotate_ms2_spectra`: raise `ValueError` with a descriptive message on malformed or non-positive charge suffix in ProForma string; fall back to precursor charge when no suffix is present
- `ms2pip_extract_targets`: validate per-spectrum intensity length against peak count; raises `Exception` instead of silently zero-filling on mismatch

### Changed

- Version bumped `0.5.0-alpha.3` → `0.5.0-beta.1`
- `LOG2_FLOOR` / `CLIP_LOG2_MIN` consolidated into a single canonical `LOG2_FLOOR_F64` constant in `src/utils.rs`; derived at use sites to avoid precision drift

### Added

- `CHANGELOG.md` (Keep a Changelog format, full history v0.1.0 – 0.5.0-beta.1)
- `README.md` populated with description, function table, supported formats, dependency attribution (rustyms/mzcore, mzdata, timsrust), and development instructions
- `test_unsupported_file_type_raises_value_error`: both io functions raise `ValueError` for unknown file extensions
- `test_no_charge_raises`: `ms2pip_compute_theoretical_mz` raises `ValueError` on chargeless ProForma (renamed from `test_no_charge_defaults`)